### PR TITLE
expose `disconnect` of naia-client for bevy

### DIFF
--- a/adapters/bevy/client/src/client.rs
+++ b/adapters/bevy/client/src/client.rs
@@ -51,6 +51,10 @@ impl<'a, P: Protocolize, C: ChannelIndex> Client<'a, P, C> {
         self.client.connect(server_address);
     }
 
+    pub fn disconnect(&mut self) {
+        self.client.disconnect();
+    }
+
     pub fn is_connected(&self) -> bool {
         self.client.is_connected()
     }


### PR DESCRIPTION
#36 makes clients about to disconnect, this is not exposed for bevy clients however.