### PR TITLE
Fixed doc warnings

### DIFF
--- a/shared/parse/src/parse.rs
+++ b/shared/parse/src/parse.rs
@@ -1,8 +1,8 @@
 //! Very limited rust parser
 //!
-//! https://doc.rust-lang.org/reference/expressions/struct-expr.html
-//! https://docs.rs/syn/0.15.44/syn/enum.Type.html
-//! https://ziglang.org/documentation/0.5.0/#toc-typeInfo
+//! <https://doc.rust-lang.org/reference/expressions/struct-expr.html>
+//! <https://docs.rs/syn/0.15.44/syn/enum.Type.html>
+//! <https://ziglang.org/documentation/0.5.0/#toc-typeInfo>
 
 use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 

--- a/shared/src/connection/standard_header.rs
+++ b/shared/src/connection/standard_header.rs
@@ -19,9 +19,9 @@ impl StandardHeader {
     /// When we compose packet headers, the local sequence becomes the sequence
     /// number of the packet, and the remote sequence becomes the ack.
     /// The ack bitfield is calculated by looking into a queue of up to 33
-    /// packets, containing sequence numbers in the range [remote sequence - 32,
-    /// remote sequence]. We set bit n (in [1,32]) in ack bits to 1 if the
-    /// sequence number remote sequence - n is in the received queue.
+    /// packets, containing sequence numbers in the range `[remote sequence - 32,
+    /// remote sequence]`. We set bit _n_ (in `[1,32]`) in ack bits to 1 if the
+    /// sequence number remote sequence - _n_ is in the received queue.
     pub fn new(
         packet_type: PacketType,
         sender_packet_index: PacketIndex,

--- a/shared/src/constants.rs
+++ b/shared/src/constants.rs
@@ -1,5 +1,5 @@
 /// The maximum of bytes that can be used for the payload of a given packet.
-/// (See #38 of http://ithare.com/64-network-dos-and-donts-for-game-engines-part-v-udp/)
+/// (See #38 of <http://ithare.com/64-network-dos-and-donts-for-game-engines-part-v-udp/>)
 pub const MTU_SIZE_BYTES: u16 = 508;
 pub const MTU_SIZE_BITS: u16 = MTU_SIZE_BYTES * 8;
 


### PR DESCRIPTION
I ran `cargo doc` on the code and noticed a couple of minor warnings. Here's a small patch to fix them