### PR TITLE
Make send non-blocking, make error handling possible

### DIFF
--- a/socket/client/src/backends/miniquad/packet_sender.rs
+++ b/socket/client/src/backends/miniquad/packet_sender.rs
@@ -7,13 +7,14 @@ pub struct PacketSender;
 
 impl PacketSender {
     /// Send a Packet to the Server
-    pub fn send(&self, payload: &[u8]) {
+    pub fn send(&self, payload: &[u8]) -> Result<(), naia_socket_shared::TrySendError<()>> {
         unsafe {
             let ptr = payload.as_ptr();
             let len = payload.len();
             let js_obj = naia_create_u8_array(ptr as _, len as _);
             naia_send(js_obj);
         }
+        Ok(())
     }
 
     /// Get the Server's Socket address

--- a/socket/client/src/backends/wasm_bindgen/packet_sender.rs
+++ b/socket/client/src/backends/wasm_bindgen/packet_sender.rs
@@ -22,11 +22,12 @@ impl PacketSender {
     }
 
     /// Send a Packet to the Server
-    pub fn send(&self, payload: &[u8]) {
+    pub fn send(&self, payload: &[u8]) -> Result<(), naia_socket_shared::TrySendError<()>> {
         let uarray: Uint8Array = payload.into();
         self.message_port
             .post_message(&uarray)
             .expect("Failed to send message");
+        Ok(())
     }
 
     /// Get the Server's Socket address

--- a/socket/shared/src/lib.rs
+++ b/socket/shared/src/lib.rs
@@ -28,6 +28,34 @@ pub use socket_config::SocketConfig;
 pub use time_queue::TimeQueue;
 pub use url_parse::{parse_server_url, url_to_socket_addr};
 
+/// This enumeration is the list of the possible error outcomes for the `send` method of packet
+/// senders.
+#[derive(Debug, Eq, PartialEq)]
+pub enum TrySendError<T> {
+    /// The data could not be sent on the channel because the channel is
+    /// currently full and sending would require blocking.
+    Full(T),
+
+    /// The receive half of the channel was explicitly closed or has been
+    /// dropped.
+    Closed(T),
+}
+
+impl<T: std::fmt::Debug> std::error::Error for TrySendError<T> {}
+
+impl<T> std::fmt::Display for TrySendError<T> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            fmt,
+            "{}",
+            match self {
+                TrySendError::Full(..) => "no available capacity",
+                TrySendError::Closed(..) => "channel closed",
+            }
+        )
+    }
+}
+
 cfg_if! {
     if #[cfg(all(target_arch = "wasm32", feature = "wbindgen", feature = "mquad"))]
     {


### PR DESCRIPTION
The PR introduces the following changes:
- Add the `TrySendError` enum to make error handling possible for the `send` method
- Make sending non-blocking (before this change, if the channel gets full, it'll block the app forever)
  - I had a weird case when I tried to send packets to the session socket, the queue just wasn't being cleared. There are likely other scenarios when the queue can get full, the error handling will also allow for some backpressure strategies