### PR TITLE
Add sequenced unreliable channels

### DIFF
--- a/shared/src/messages/channel_config.rs
+++ b/shared/src/messages/channel_config.rs
@@ -64,6 +64,7 @@ impl<C: ChannelIndex> Channel<C> {
     pub fn reliable(&self) -> bool {
         match &self.mode {
             ChannelMode::UnorderedUnreliable => false,
+            ChannelMode::SequencedUnreliable => false,
             ChannelMode::UnorderedReliable(_) => true,
             ChannelMode::OrderedReliable(_) => true,
             ChannelMode::TickBuffered(_) => false,
@@ -121,6 +122,7 @@ impl TickBufferSettings {
 #[derive(Clone)]
 pub enum ChannelMode {
     UnorderedUnreliable,
+    SequencedUnreliable,
     UnorderedReliable(ReliableSettings),
     OrderedReliable(ReliableSettings),
     TickBuffered(TickBufferSettings),
@@ -150,6 +152,7 @@ mod define_default_channels {
     #[derive_serde]
     pub enum DefaultChannels {
         UnorderedUnreliable,
+        SequencedUnreliable,
         UnorderedReliable,
         OrderedReliable,
         TickBuffered,
@@ -170,6 +173,11 @@ const DEFAULT_CHANNEL_CONFIG: &[Channel<DefaultChannels>] = &[
         index: DefaultChannels::UnorderedUnreliable,
         direction: ChannelDirection::Bidirectional,
         mode: ChannelMode::UnorderedUnreliable,
+    },
+    Channel {
+        index: DefaultChannels::SequencedUnreliable,
+        direction: ChannelDirection::Bidirectional,
+        mode: ChannelMode::SequencedUnreliable,
     },
     Channel {
         index: DefaultChannels::UnorderedReliable,

--- a/shared/src/messages/message_channel.rs
+++ b/shared/src/messages/message_channel.rs
@@ -4,9 +4,11 @@ use naia_socket_shared::Instant;
 use crate::types::MessageId;
 
 pub trait ChannelSender<P>: Send + Sync {
+    /// Queues an Message to be transmitted to the remote host into an internal buffer
     fn send_message(&mut self, message: P);
     fn collect_messages(&mut self, now: &Instant, rtt_millis: &f32);
     fn has_messages(&self) -> bool;
+    /// Gets messages from the internal buffer and writes it to the channel_writer
     fn write_messages(
         &mut self,
         channel_writer: &dyn ChannelWriter<P>,
@@ -16,11 +18,13 @@ pub trait ChannelSender<P>: Send + Sync {
 }
 
 pub trait ChannelReceiver<P>: Send + Sync {
+    /// Read messages from the channel_reader into an internal buffer
     fn read_messages(
         &mut self,
         channel_reader: &dyn ChannelReader<P>,
         reader: &mut BitReader,
     ) -> Result<(), SerdeErr>;
+    /// Read messages from an internal buffer and return their content
     fn receive_messages(&mut self) -> Vec<P>;
 }
 

--- a/shared/src/messages/message_list_header.rs
+++ b/shared/src/messages/message_list_header.rs
@@ -1,5 +1,6 @@
 use naia_serde::{BitReader, BitWrite, Serde, SerdeErr, UnsignedVariableInteger};
 
+/// Write the number of messages in the packet header
 pub fn write<S: BitWrite, T: Into<i128>>(writer: &mut S, message_count: T) {
     let mut message_count_i128: i128 = message_count.into();
     let has_messages: bool = message_count_i128 > 0;
@@ -16,6 +17,7 @@ pub fn write<S: BitWrite, T: Into<i128>>(writer: &mut S, message_count: T) {
     }
 }
 
+/// Read the number of messages from the packet header
 pub fn read(reader: &mut BitReader) -> Result<u16, SerdeErr> {
     let has_messages = bool::de(reader)?;
 

--- a/shared/src/messages/message_manager.rs
+++ b/shared/src/messages/message_manager.rs
@@ -14,6 +14,8 @@ use super::{
     message_channel::{ChannelReader, ChannelReceiver, ChannelSender, ChannelWriter},
     ordered_reliable_receiver::OrderedReliableReceiver,
     reliable_sender::ReliableSender,
+    sequenced_unreliable_receiver::SequencedUnreliableReceiver,
+    sequenced_unreliable_sender::SequencedUnreliableSender,
     unordered_reliable_receiver::UnorderedReliableReceiver,
     unordered_unreliable_receiver::UnorderedUnreliableReceiver,
     unordered_unreliable_sender::UnorderedUnreliableSender,
@@ -55,6 +57,12 @@ impl<P: Protocolize, C: ChannelIndex> MessageManager<P, C> {
                         Box::new(UnorderedUnreliableSender::new()),
                     );
                 }
+                ChannelMode::SequencedUnreliable => {
+                    channel_senders.insert(
+                        channel_index.clone(),
+                        Box::new(SequencedUnreliableSender::new()),
+                    );
+                }
                 ChannelMode::UnorderedReliable(settings) => {
                     channel_senders.insert(
                         channel_index.clone(),
@@ -92,6 +100,12 @@ impl<P: Protocolize, C: ChannelIndex> MessageManager<P, C> {
                     channel_receivers.insert(
                         channel_index.clone(),
                         Box::new(UnorderedUnreliableReceiver::new()),
+                    );
+                }
+                ChannelMode::SequencedUnreliable => {
+                    channel_receivers.insert(
+                        channel_index.clone(),
+                        Box::new(SequencedUnreliableReceiver::new()),
                     );
                 }
                 ChannelMode::UnorderedReliable(_) => {

--- a/shared/src/messages/mod.rs
+++ b/shared/src/messages/mod.rs
@@ -5,6 +5,8 @@ pub mod message_manager;
 pub mod ordered_reliable_receiver;
 pub mod reliable_receiver;
 pub mod reliable_sender;
+pub mod sequenced_unreliable_receiver;
+pub mod sequenced_unreliable_sender;
 pub mod unordered_reliable_receiver;
 pub mod unordered_unreliable_receiver;
 pub mod unordered_unreliable_sender;

--- a/shared/src/messages/reliable_receiver.rs
+++ b/shared/src/messages/reliable_receiver.rs
@@ -29,7 +29,7 @@ impl<P> ReliableReceiver<P> {
         Ok(output)
     }
 
-    fn read_incoming_message(
+    pub fn read_incoming_message(
         channel_reader: &dyn ChannelReader<P>,
         reader: &mut BitReader,
         last_read_id: &Option<MessageId>,

--- a/shared/src/messages/sequenced_unreliable_receiver.rs
+++ b/shared/src/messages/sequenced_unreliable_receiver.rs
@@ -1,0 +1,61 @@
+use std::{collections::VecDeque, mem};
+
+use naia_serde::{BitReader, SerdeErr};
+
+use crate::{message_list_header, sequence_greater_than, types::MessageId};
+
+use super::{
+    message_channel::{ChannelReader, ChannelReceiver},
+    reliable_receiver::ReliableReceiver,
+};
+
+pub struct SequencedUnreliableReceiver<P> {
+    most_recent_received_message_id: Option<MessageId>,
+    incoming_messages: VecDeque<P>,
+}
+
+impl<P> SequencedUnreliableReceiver<P> {
+    pub fn new() -> Self {
+        Self {
+            most_recent_received_message_id: None,
+            incoming_messages: VecDeque::new(),
+        }
+    }
+
+
+    fn recv_message(&mut self, message: P) {
+        self.incoming_messages.push_back(message);
+    }
+}
+
+impl<P: Send + Sync> ChannelReceiver<P> for SequencedUnreliableReceiver<P> {
+    /// Read messages and add them to the buffer, discard messages that are older
+    /// than the most recent received message
+    fn read_messages(
+        &mut self,
+        channel_reader: &dyn ChannelReader<P>,
+        reader: &mut BitReader,
+    ) -> Result<(), SerdeErr> {
+        let message_count = message_list_header::read(reader)?;
+
+        for _x in 0..message_count {
+            let (message_id, message) = ReliableReceiver::read_incoming_message(
+                channel_reader, reader, &self.most_recent_received_message_id)?;
+
+            // only process the message if it is the most recent one
+            if let Some(most_recent_id) = self.most_recent_received_message_id {
+                if sequence_greater_than(message_id, most_recent_id) {
+                    self.recv_message(message);
+                    self.most_recent_received_message_id = Some(message_id);
+                }
+            } else {
+                self.most_recent_received_message_id = Some(message_id);
+            }
+        }
+        Ok(())
+    }
+
+    fn receive_messages(&mut self) -> Vec<P> {
+        Vec::from(mem::take(&mut self.incoming_messages))
+    }
+}

--- a/shared/src/messages/sequenced_unreliable_sender.rs
+++ b/shared/src/messages/sequenced_unreliable_sender.rs
@@ -1,0 +1,148 @@
+use std::collections::VecDeque;
+
+use naia_serde::{BitCounter, BitWrite, BitWriter, Serde, UnsignedVariableInteger};
+use naia_socket_shared::Instant;
+
+use crate::{constants::MTU_SIZE_BITS, types::MessageId, wrapping_diff};
+
+use super::{
+    message_channel::{ChannelSender, ChannelWriter},
+    message_list_header::write,
+};
+
+pub struct SequencedUnreliableSender<P: Send> {
+    /// Buffer of the next messages to send along with their MessageId
+    outgoing_messages: VecDeque<(MessageId, P)>,
+    /// Next message id to use (not yet used in the buffer)
+    next_send_message_id: MessageId,
+}
+
+impl<P: Send> SequencedUnreliableSender<P> {
+    pub fn new() -> Self {
+        Self {
+            outgoing_messages: VecDeque::new(),
+            next_send_message_id: 0,
+        }
+    }
+
+    /// Write a message in the channel_writer. Will include the wrapped message id and the message
+    /// data
+    fn write_outgoing_message(
+        &self,
+        channel_writer: &dyn ChannelWriter<P>,
+        bit_writer: &mut dyn BitWrite,
+        last_written_id: &Option<MessageId>,
+        message_id: &MessageId,
+        message: &P,
+    ) {
+        if let Some(last_id) = last_written_id {
+            // write message id diff
+            let id_diff = wrapping_diff(*last_id, *message_id);
+            let id_diff_encoded = UnsignedVariableInteger::<3>::new(id_diff);
+            id_diff_encoded.ser(bit_writer);
+        } else {
+            // write message id
+            message_id.ser(bit_writer);
+        }
+
+        channel_writer.write(bit_writer, message);
+    }
+}
+
+impl<P: Send + Sync> ChannelSender<P> for SequencedUnreliableSender<P> {
+    fn send_message(&mut self, message: P) {
+        self.outgoing_messages.push_back((self.next_send_message_id, message));
+        self.next_send_message_id = self.next_send_message_id.wrapping_add(1);
+    }
+
+    fn collect_messages(&mut self, _: &Instant, _: &f32) {
+        // not necessary for an unreliable channel
+    }
+
+    fn has_messages(&self) -> bool {
+        !self.outgoing_messages.is_empty()
+    }
+
+    /// Write messages from the buffer into the channel
+    /// Include a wrapped message id for sequencing purposes
+    fn write_messages(
+        &mut self,
+        channel_writer: &dyn ChannelWriter<P>,
+        bit_writer: &mut BitWriter,
+    ) -> Option<Vec<MessageId>> {
+        let mut message_count: u16 = 0;
+
+        // Header
+        {
+            // Measure
+            let current_packet_size = bit_writer.bit_count();
+            if current_packet_size > MTU_SIZE_BITS {
+                write(bit_writer, 0);
+                return None;
+            }
+
+            let mut counter = BitCounter::new();
+
+            //TODO: message_count is inaccurate here and may be different than final, does
+            // this matter?
+            write(&mut counter, 123);
+
+            // Check for overflow
+            if current_packet_size + counter.bit_count() > MTU_SIZE_BITS {
+                write(bit_writer, 0);
+                return None;
+            }
+
+            // Find how many messages will fit into the packet
+            let mut last_written_id: Option<MessageId> = None;
+            let mut index = 0;
+            loop {
+                if index >= self.outgoing_messages.len() {
+                    break;
+                }
+
+                let (message_id, message) = self.outgoing_messages.get(index).unwrap();
+                self.write_outgoing_message(
+                    channel_writer,
+                    &mut counter,
+                    &last_written_id,
+                    message_id,
+                    message,
+                );
+                last_written_id = Some(*message_id);
+                if current_packet_size + counter.bit_count() <= MTU_SIZE_BITS {
+                    message_count += 1;
+                } else {
+                    break;
+                }
+
+                index += 1;
+            }
+        }
+
+        // Write header
+        write(bit_writer, message_count);
+
+        // Messages
+        {
+            let mut last_written_id: Option<MessageId> = None;
+            for _ in 0..message_count {
+                // Pop and write message
+                let (message_id, message) = self.outgoing_messages.pop_front().unwrap();
+                self.write_outgoing_message(
+                    channel_writer,
+                    bit_writer,
+                    &last_written_id,
+                    &message_id,
+                    &message,
+                );
+                last_written_id = Some(message_id);
+            }
+            None
+        }
+    }
+
+    fn notify_message_delivered(&mut self, _: &MessageId) {
+        // not necessary for an unreliable channel
+    }
+}


### PR DESCRIPTION
This PR aims at adding SequencedUnreliable channels, as defined in: https://timonpost.github.io/laminar/reliability/reliability.html#unreliable-sequenced

I.e. messages are sent unreliably, and only the latest ones are processed.

I basically combined some bits and pieces from unordered_unreliable (e.g. not having internal buffers) and reliable channels (adding a wrapping message id).

One thing I'm unsure about is why the message_id is a `wrapping_diff` with the previous message_id, instead of simply being a wrapping id. This may actually mean that my implementation is not correct? I'd need more info on why we're using wrapping_diff