### PR TITLE
Add replicate for tuple structs

### DIFF
--- a/shared/tests/derive_replicate.rs
+++ b/shared/tests/derive_replicate.rs
@@ -1,26 +1,45 @@
 mod some_protocol {
-    use super::some_replica::StringHolder;
+    use super::some_named_replica::NamedStringHolder;
+    use super::some_tuple_replica::TupleStringHolder;
     use naia_shared::Protocolize;
 
     #[derive(Protocolize)]
     pub enum SomeProtocol {
-        StringHolder(StringHolder),
+        NamedStringHolder(NamedStringHolder),
+        TupleStringHolder(TupleStringHolder)
     }
 }
 
-mod some_replica {
+mod some_named_replica {
     use naia_shared::{Property, Replicate};
 
     #[derive(Replicate)]
     #[protocol_path = "super::some_protocol::SomeProtocol"]
-    pub struct StringHolder {
+    pub struct NamedStringHolder {
         pub string_1: Property<String>,
         pub string_2: Property<String>,
     }
 
-    impl StringHolder {
+    impl NamedStringHolder {
         pub fn new(string_1: &str, string_2: &str) -> Self {
-            return StringHolder::new_complete(string_1.to_string(), string_2.to_string());
+            return NamedStringHolder::new_complete(string_1.to_string(), string_2.to_string());
+        }
+    }
+}
+
+mod some_tuple_replica {
+    use naia_shared::{Property, Replicate};
+
+    #[derive(Replicate)]
+    #[protocol_path = "super::some_protocol::SomeProtocol"]
+    pub struct TupleStringHolder(
+        pub Property<String>,
+        pub Property<String>,
+    );
+
+    impl TupleStringHolder {
+        pub fn new(string_1: &str, string_2: &str) -> Self {
+            return TupleStringHolder::new_complete(string_1.to_string(), string_2.to_string());
         }
     }
 }
@@ -31,14 +50,15 @@ use naia_shared::{
 };
 
 use some_protocol::SomeProtocol;
-use some_replica::StringHolder;
+use some_named_replica::NamedStringHolder;
+use some_tuple_replica::TupleStringHolder;
 
 #[test]
-fn read_write_protocol() {
+fn read_write_named_replica() {
     // Write
     let mut writer = BitWriter::new();
 
-    let in_1 = SomeProtocol::StringHolder(StringHolder::new("hello world", "goodbye world"));
+    let in_1 = SomeProtocol::NamedStringHolder(NamedStringHolder::new("hello world", "goodbye world"));
 
     in_1.write(&mut writer, &FakeEntityConverter);
 
@@ -51,12 +71,40 @@ fn read_write_protocol() {
     let out_1 = SomeProtocol::read(&mut reader, &FakeEntityConverter)
         .expect("should deserialize correctly");
 
-    let typed_in_1 = in_1.cast_ref::<StringHolder>().unwrap();
-    let typed_out_1 = out_1.cast_ref::<StringHolder>().unwrap();
+    let typed_in_1 = in_1.cast_ref::<NamedStringHolder>().unwrap();
+    let typed_out_1 = out_1.cast_ref::<NamedStringHolder>().unwrap();
     assert!(typed_in_1.string_1.equals(&typed_out_1.string_1));
     assert!(typed_in_1.string_2.equals(&typed_out_1.string_2));
     assert_eq!(*typed_in_1.string_1, "hello world".to_string());
     assert_eq!(*typed_in_1.string_2, "goodbye world".to_string());
     assert_eq!(*typed_out_1.string_1, "hello world".to_string());
     assert_eq!(*typed_out_1.string_2, "goodbye world".to_string());
+}
+
+#[test]
+fn read_write_tuple_replica() {
+    // Write
+    let mut writer = BitWriter::new();
+
+    let in_1 = SomeProtocol::TupleStringHolder(TupleStringHolder::new("hello world", "goodbye world"));
+
+    in_1.write(&mut writer, &FakeEntityConverter);
+
+    let (buffer_length, buffer) = writer.flush();
+
+    // Read
+
+    let mut reader = BitReader::new(&buffer[..buffer_length]);
+
+    let out_1 = SomeProtocol::read(&mut reader, &FakeEntityConverter)
+        .expect("should deserialize correctly");
+
+    let typed_in_1 = in_1.cast_ref::<TupleStringHolder>().unwrap();
+    let typed_out_1 = out_1.cast_ref::<TupleStringHolder>().unwrap();
+    assert!(typed_in_1.0.equals(&typed_out_1.0));
+    assert!(typed_in_1.1.equals(&typed_out_1.1));
+    assert_eq!(*typed_in_1.0, "hello world".to_string());
+    assert_eq!(*typed_in_1.1, "goodbye world".to_string());
+    assert_eq!(*typed_out_1.0, "hello world".to_string());
+    assert_eq!(*typed_out_1.1, "goodbye world".to_string());
 }

--- a/shared/tests/derive_replicate.rs
+++ b/shared/tests/derive_replicate.rs
@@ -6,7 +6,7 @@ mod some_protocol {
     #[derive(Protocolize)]
     pub enum SomeProtocol {
         NamedStringHolder(NamedStringHolder),
-        TupleStringHolder(TupleStringHolder)
+        TupleStringHolder(TupleStringHolder),
     }
 }
 
@@ -32,10 +32,7 @@ mod some_tuple_replica {
 
     #[derive(Replicate)]
     #[protocol_path = "super::some_protocol::SomeProtocol"]
-    pub struct TupleStringHolder(
-        pub Property<String>,
-        pub Property<String>,
-    );
+    pub struct TupleStringHolder(pub Property<String>, pub Property<String>);
 
     impl TupleStringHolder {
         pub fn new(string_1: &str, string_2: &str) -> Self {
@@ -49,8 +46,8 @@ use naia_shared::{
     FakeEntityConverter, Protocolize,
 };
 
-use some_protocol::SomeProtocol;
 use some_named_replica::NamedStringHolder;
+use some_protocol::SomeProtocol;
 use some_tuple_replica::TupleStringHolder;
 
 #[test]
@@ -58,7 +55,8 @@ fn read_write_named_replica() {
     // Write
     let mut writer = BitWriter::new();
 
-    let in_1 = SomeProtocol::NamedStringHolder(NamedStringHolder::new("hello world", "goodbye world"));
+    let in_1 =
+        SomeProtocol::NamedStringHolder(NamedStringHolder::new("hello world", "goodbye world"));
 
     in_1.write(&mut writer, &FakeEntityConverter);
 
@@ -86,7 +84,8 @@ fn read_write_tuple_replica() {
     // Write
     let mut writer = BitWriter::new();
 
-    let in_1 = SomeProtocol::TupleStringHolder(TupleStringHolder::new("hello world", "goodbye world"));
+    let in_1 =
+        SomeProtocol::TupleStringHolder(TupleStringHolder::new("hello world", "goodbye world"));
 
     in_1.write(&mut writer, &FakeEntityConverter);
 


### PR DESCRIPTION
# Context

This PR is mostly for usability.
There are a lot of components that I want to replicate that are wrapper or tuple structs, such as:
```
#[derive(Component, Replicate)]
pub struct Velocity_(pub Property<f32>)
```

Deriving `Replicate` on those structs was failing because `Replicate` only handled named structs. 
I updated the `Replicate `derive logic to handle structs that have unnamed fields.

# Test

Added a unit test similar to the named struct one


