### PR TITLE
WIP: A whole bunch of updates to the socket crates

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -16,5 +16,3 @@ impl fmt::Display for NaiaClientError {
 }
 
 impl Error for NaiaClientError {}
-unsafe impl Send for NaiaClientError {}
-unsafe impl Sync for NaiaClientError {}

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -14,5 +14,3 @@ impl fmt::Display for NaiaServerError {
 }
 
 impl Error for NaiaServerError {}
-unsafe impl Send for NaiaServerError {}
-unsafe impl Sync for NaiaServerError {}

--- a/socket/client/src/backends/miniquad/packet_sender.rs
+++ b/socket/client/src/backends/miniquad/packet_sender.rs
@@ -7,7 +7,7 @@ pub struct PacketSender;
 
 impl PacketSender {
     /// Send a Packet to the Server
-    pub fn send(&self, payload: &[u8]) {
+    pub fn send(&self, payload: &[u8]) -> Result<(), naia_socket_shared::ChannelClosedError<()>> {
         unsafe {
             let ptr = payload.as_ptr();
             let len = payload.len();

--- a/socket/client/src/backends/native/packet_receiver.rs
+++ b/socket/client/src/backends/native/packet_receiver.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use webrtc_unreliable_client::{AddrCell, ServerAddr as RTCServerAddr};
 
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::{
     error::NaiaClientSocketError, packet_receiver::PacketReceiverTrait, server_addr::ServerAddr,
@@ -11,14 +11,14 @@ use crate::{
 #[derive(Clone)]
 pub struct PacketReceiverImpl {
     server_addr: AddrCell,
-    receiver_channel: Arc<Mutex<Receiver<Box<[u8]>>>>,
+    receiver_channel: Arc<Mutex<UnboundedReceiver<Box<[u8]>>>>,
     receive_buffer: Vec<u8>,
 }
 
 impl PacketReceiverImpl {
     /// Create a new PacketReceiver, if supplied with the Server's address & a
     /// reference back to the parent Socket
-    pub fn new(server_addr: AddrCell, receiver_channel: Receiver<Box<[u8]>>) -> Self {
+    pub fn new(server_addr: AddrCell, receiver_channel: UnboundedReceiver<Box<[u8]>>) -> Self {
         PacketReceiverImpl {
             server_addr,
             receiver_channel: Arc::new(Mutex::new(receiver_channel)),

--- a/socket/client/src/backends/native/socket.rs
+++ b/socket/client/src/backends/native/socket.rs
@@ -1,5 +1,3 @@
-extern crate log;
-
 use naia_socket_shared::{parse_server_url, SocketConfig};
 
 use webrtc_unreliable_client::Socket as RTCSocket;
@@ -42,12 +40,12 @@ impl Socket {
         );
         let conditioner_config = self.config.link_condition.clone();
 
-        let (addr_cell, to_server_sender, to_client_receiver) =
-            get_runtime().block_on(RTCSocket::connect(&server_session_string));
+        let (socket, io) = RTCSocket::new();
+        get_runtime().spawn(async move { socket.connect(&server_session_string).await });
 
         // Setup Packet Sender & Receiver
-        let packet_sender = PacketSender::new(addr_cell.clone(), to_server_sender);
-        let packet_receiver_impl = PacketReceiverImpl::new(addr_cell, to_client_receiver);
+        let packet_sender = PacketSender::new(io.addr_cell.clone(), io.to_server_sender);
+        let packet_receiver_impl = PacketReceiverImpl::new(io.addr_cell, io.to_client_receiver);
 
         let receiver: Box<dyn PacketReceiverTrait> = {
             let inner_receiver = Box::new(packet_receiver_impl);
@@ -64,7 +62,8 @@ impl Socket {
         });
     }
 
-    /// Returns whether or not the Socket is currently connected to the server
+    /// Returns whether or not the connect method was called (doesn't necessarily indicate that the
+    /// connection is fully established).
     pub fn is_connected(&self) -> bool {
         self.io.is_some()
     }
@@ -79,8 +78,7 @@ impl Socket {
             .clone();
     }
 
-    /// Gets a PacketReceiver which can be used to receive packets from the
-    /// Socket
+    /// Gets a PacketReceiver which can be used to receive packets from the Socket
     pub fn packet_receiver(&self) -> PacketReceiver {
         return self
             .io

--- a/socket/client/src/backends/wasm_bindgen/data_port.rs
+++ b/socket/client/src/backends/wasm_bindgen/data_port.rs
@@ -1,5 +1,3 @@
-extern crate log;
-
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 use wasm_bindgen::{closure::Closure, JsCast};

--- a/socket/client/src/backends/wasm_bindgen/packet_receiver.rs
+++ b/socket/client/src/backends/wasm_bindgen/packet_receiver.rs
@@ -47,6 +47,3 @@ impl PacketReceiverTrait for PacketReceiverImpl {
         self.server_addr.get()
     }
 }
-
-unsafe impl Send for PacketReceiverImpl {}
-unsafe impl Sync for PacketReceiverImpl {}

--- a/socket/client/src/backends/wasm_bindgen/packet_sender.rs
+++ b/socket/client/src/backends/wasm_bindgen/packet_sender.rs
@@ -22,11 +22,12 @@ impl PacketSender {
     }
 
     /// Send a Packet to the Server
-    pub fn send(&self, payload: &[u8]) {
+    pub fn send(&self, payload: &[u8]) -> Result<(), naia_socket_shared::ChannelClosedError<()>> {
         let uarray: Uint8Array = payload.into();
         self.message_port
             .post_message(&uarray)
             .expect("Failed to send message");
+        Ok(())
     }
 
     /// Get the Server's Socket address
@@ -34,6 +35,3 @@ impl PacketSender {
         self.server_addr.get()
     }
 }
-
-unsafe impl Send for PacketSender {}
-unsafe impl Sync for PacketSender {}

--- a/socket/client/src/backends/wasm_bindgen/socket.rs
+++ b/socket/client/src/backends/wasm_bindgen/socket.rs
@@ -1,5 +1,3 @@
-extern crate log;
-
 use std::net::SocketAddr;
 
 use naia_socket_shared::SocketConfig;
@@ -12,7 +10,7 @@ use crate::{
 
 use super::{
     addr_cell::AddrCell, data_channel::DataChannel, data_port::DataPort,
-    packet_receiver::PacketReceiverImpl, packet_sender::PacketSender,
+    packet_sender::PacketSender, PacketReceiverImpl,
 };
 
 /// A client-side socket which communicates with an underlying unordered &
@@ -114,6 +112,3 @@ impl Socket {
             .clone();
     }
 }
-
-unsafe impl Send for Socket {}
-unsafe impl Sync for Socket {}

--- a/socket/client/src/packet_receiver.rs
+++ b/socket/client/src/packet_receiver.rs
@@ -28,7 +28,7 @@ impl PacketReceiver {
 // Trait
 
 /// Used to receive packets from the Client Socket
-pub trait PacketReceiverTrait: PacketReceiverClone + Send + Sync {
+pub trait PacketReceiverTrait: PacketReceiverClone {
     /// Receives a packet from the Client Socket
     fn receive(&mut self) -> Result<Option<&[u8]>, NaiaClientSocketError>;
     /// Get the Server's Socket address

--- a/socket/server/src/error.rs
+++ b/socket/server/src/error.rs
@@ -20,5 +20,3 @@ impl fmt::Display for NaiaServerSocketError {
 }
 
 impl Error for NaiaServerSocketError {}
-//unsafe impl Send for NaiaServerSocketError {}
-//unsafe impl Sync for NaiaServerSocketError {}

--- a/socket/shared/src/lib.rs
+++ b/socket/shared/src/lib.rs
@@ -28,34 +28,6 @@ pub use socket_config::SocketConfig;
 pub use time_queue::TimeQueue;
 pub use url_parse::{parse_server_url, url_to_socket_addr};
 
-/// This enumeration is the list of the possible error outcomes for the `send` method of packet
-/// senders.
-#[derive(Debug, Eq, PartialEq)]
-pub enum TrySendError<T> {
-    /// The data could not be sent on the channel because the channel is
-    /// currently full and sending would require blocking.
-    Full(T),
-
-    /// The receive half of the channel was explicitly closed or has been
-    /// dropped.
-    Closed(T),
-}
-
-impl<T: std::fmt::Debug> std::error::Error for TrySendError<T> {}
-
-impl<T> std::fmt::Display for TrySendError<T> {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            fmt,
-            "{}",
-            match self {
-                TrySendError::Full(..) => "no available capacity",
-                TrySendError::Closed(..) => "channel closed",
-            }
-        )
-    }
-}
-
 #[derive(Debug, Eq, PartialEq)]
 pub struct ChannelClosedError<T>(pub T);
 

--- a/socket/shared/src/lib.rs
+++ b/socket/shared/src/lib.rs
@@ -28,6 +28,45 @@ pub use socket_config::SocketConfig;
 pub use time_queue::TimeQueue;
 pub use url_parse::{parse_server_url, url_to_socket_addr};
 
+/// This enumeration is the list of the possible error outcomes for the `send` method of packet
+/// senders.
+#[derive(Debug, Eq, PartialEq)]
+pub enum TrySendError<T> {
+    /// The data could not be sent on the channel because the channel is
+    /// currently full and sending would require blocking.
+    Full(T),
+
+    /// The receive half of the channel was explicitly closed or has been
+    /// dropped.
+    Closed(T),
+}
+
+impl<T: std::fmt::Debug> std::error::Error for TrySendError<T> {}
+
+impl<T> std::fmt::Display for TrySendError<T> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            fmt,
+            "{}",
+            match self {
+                TrySendError::Full(..) => "no available capacity",
+                TrySendError::Closed(..) => "channel closed",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ChannelClosedError<T>(pub T);
+
+impl<T: std::fmt::Debug> std::error::Error for ChannelClosedError<T> {}
+
+impl<T> std::fmt::Display for ChannelClosedError<T> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "channel closed")
+    }
+}
+
 cfg_if! {
     if #[cfg(all(target_arch = "wasm32", feature = "wbindgen", feature = "mquad"))]
     {


### PR DESCRIPTION
Depends on https://github.com/naia-lib/webrtc-unreliable-client/pull/5

Probably, there are some missing bits in `miniquad` to have changes consistent. Also, the PR definitely breaks a lot of other crates in the workspace, which will have to be fixed.

I'm not sure I'll have time to finish this PR tbh, having lots of stress due to work and the war in Ukraine.
@connorcarpenter assuming you agree with the changes, may I pass the PR to you (to polish and fix the rest of the crates)?

Also, for a bit of context:
I'm trying to resurrect the discontinued `bevy_networking_turbulence` crate. I have a WIP branch that depends on the changes introduced in this PR: https://github.com/mvlabat/bevy_disturbulence/tree/wip