### PR TITLE
Improve derive Replicate

### DIFF
--- a/shared/derive/Cargo.toml
+++ b/shared/derive/Cargo.toml
@@ -24,5 +24,5 @@ proc-macro = true
 naia-serde-derive = { version = "0.13", path = "../serde/derive" }
 naia-parse = { version = "0.13", path = "../parse" }
 proc-macro2 = "1.0"
-syn = { version = "1.0.86", features = ["clone-impls", "extra-traits"] }
+syn = { version = "1.0.86", features = ["clone-impls"] }
 quote = "1.0"

--- a/shared/derive/Cargo.toml
+++ b/shared/derive/Cargo.toml
@@ -24,5 +24,5 @@ proc-macro = true
 naia-serde-derive = { version = "0.13", path = "../serde/derive" }
 naia-parse = { version = "0.13", path = "../parse" }
 proc-macro2 = "1.0"
-syn = { version = "1.0.86", features = ["clone-impls"] }
+syn = { version = "1.0.86", features = ["clone-impls", "extra-traits"] }
 quote = "1.0"

--- a/shared/derive/src/replicate.rs
+++ b/shared/derive/src/replicate.rs
@@ -238,9 +238,7 @@ fn properties(input: &DeriveInput) -> Vec<Property> {
                     }
                 }
             }
-            Fields::Unit => {
-                panic!("Cannot derive Replicate on unit structs");
-            }
+            Fields::Unit => {}
         }
     } else {
         panic!("Can only derive Replicate on a struct");

--- a/shared/derive/src/replicate.rs
+++ b/shared/derive/src/replicate.rs
@@ -49,7 +49,7 @@ pub fn replicate_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream
     let write_method = write_method(&properties, is_replica_tuple_struct);
     let write_update_method = write_update_method(&enum_name, &properties, is_replica_tuple_struct);
     let has_entity_properties = has_entity_properties_method(&properties);
-    let entities = entities_method(&properties);
+    let entities = entities_method(&properties, is_replica_tuple_struct);
 
     let gen = quote! {
         use std::{rc::Rc, cell::RefCell, io::Cursor};
@@ -807,12 +807,12 @@ fn has_entity_properties_method(properties: &[Property]) -> TokenStream {
     }
 }
 
-fn entities_method(properties: &[Property]) -> TokenStream {
+fn entities_method(properties: &[Property], is_replica_tuple_struct: bool) -> TokenStream {
     let mut body = quote! {};
 
-    for property in properties.iter() {
-        if let Property::Entity(entity_prop) = property {
-            let field_name = &entity_prop.variable_name;
+    for (index, property) in properties.iter().enumerate() {
+        if let Property::Entity(_) = property {
+            let field_name = get_field_name(property, index, is_replica_tuple_struct);
             let body_add_right = quote! {
                 output.extend(self.#field_name.entities());
             };

--- a/shared/derive/src/replicate.rs
+++ b/shared/derive/src/replicate.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Punct, Spacing, Span, TokenStream};
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Fields, GenericArgument, Ident, Lit, Meta, Path, PathArguments, Result, Type, Index, Member};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, GenericArgument, Ident, Index, Lit, Member, Meta, Path, PathArguments, Result, Type, PathSegment, parse_str};
 
 const UNNAMED_FIELD_PREFIX: &'static str = "unnamed_field_";
 
@@ -56,6 +56,7 @@ pub fn replicate_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         use naia_shared::{
             DiffMask, PropertyMutate, ReplicateSafe, PropertyMutator, ComponentUpdate,
             Protocolize, ReplicaDynRef, ReplicaDynMut, NetEntityHandleConverter,
+            ReplicableProperty, ReplicableEntityProperty,
             serde::{BitReader, BitWrite, BitWriter, OwnedBitReader, Serde, SerdeErr},
         };
         use #protocol_path::{#protocol_name, #protocol_kind_name};
@@ -100,11 +101,15 @@ pub struct NormalProperty {
     pub variable_name: Ident,
     pub inner_type: Type,
     pub uppercase_variable_name: Ident,
+    /// type implementing ReplicableProperty
+    pub replicable_property_type: Type,
 }
 
 pub struct EntityProperty {
     pub variable_name: Ident,
     pub uppercase_variable_name: Ident,
+    /// type implementing ReplicableEntityProperty
+    pub replicable_entity_property_type: Type,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -135,7 +140,7 @@ fn get_field_name(property: &Property, index: usize, is_replica_tuple_struct: bo
 }
 
 impl Property {
-    pub fn normal(variable_name: Ident, inner_type: Type) -> Self {
+    pub fn normal(variable_name: Ident, inner_type: Type, replicable_property_type: Type) -> Self {
         Self::Normal(NormalProperty {
             variable_name: variable_name.clone(),
             inner_type,
@@ -143,16 +148,18 @@ impl Property {
                 variable_name.to_string().to_uppercase().as_str(),
                 Span::call_site(),
             ),
+            replicable_property_type: replicable_property_type,
         })
     }
 
-    pub fn entity(variable_name: Ident) -> Self {
+    pub fn entity(variable_name: Ident, replicable_entity_property_type: Type) -> Self {
         Self::Entity(EntityProperty {
             variable_name: variable_name.clone(),
             uppercase_variable_name: Ident::new(
                 variable_name.to_string().to_uppercase().as_str(),
                 Span::call_site(),
             ),
+            replicable_entity_property_type: replicable_entity_property_type,
         })
     }
 
@@ -171,8 +178,41 @@ impl Property {
     }
 }
 
+
+/// Add the replicable properties
+/// (either Property<T>, EntityProperty, or a Container<EntityProperty>)
 fn properties(input: &DeriveInput) -> Vec<Property> {
     let mut fields = Vec::new();
+
+    let mut add_fields = |property_seg: &PathSegment, variable_name: &Ident| {
+        let property_type = &property_seg.ident;
+        // EntityProperty
+        if property_type == "EntityProperty" {
+            fields.push(Property::entity(
+                variable_name.clone(),
+                parse_str::<Type>("EntityProperty").unwrap()
+            ));
+        }
+        // VecDequeEntityProperty
+        else if property_type == "VecDequeEntityProperty" {
+            fields.push(Property::entity(
+                variable_name.clone(),
+                parse_str::<Type>("VecDequeEntityProperty").unwrap()
+            ));
+        }
+        // Property
+        else if property_type == "Property" {
+            if let PathArguments::AngleBracketed(angle_args) = &property_seg.arguments {
+                if let Some(GenericArgument::Type(inner_type)) = angle_args.args.first() {
+                    fields.push(Property::normal(
+                        variable_name.clone(),
+                        inner_type.clone(),
+                        parse_str::<Type>("Property").unwrap()
+                    ));
+                }
+            }
+        }
+    };
 
     if let Data::Struct(data_struct) = &input.data {
         match &data_struct.fields {
@@ -181,23 +221,7 @@ fn properties(input: &DeriveInput) -> Vec<Property> {
                     if let Some(variable_name) = &field.ident {
                         if let Type::Path(type_path) = &field.ty {
                             if let Some(property_seg) = type_path.path.segments.first() {
-                                let property_type = property_seg.ident.clone();
-                                if property_type == "EntityProperty" {
-                                    fields.push(Property::entity(variable_name.clone()));
-                                    continue;
-                                } else if let PathArguments::AngleBracketed(angle_args) =
-                                    &property_seg.arguments
-                                {
-                                    if let Some(GenericArgument::Type(inner_type)) =
-                                        angle_args.args.first()
-                                    {
-                                        fields.push(Property::normal(
-                                            variable_name.clone(),
-                                            inner_type.clone(),
-                                        ));
-                                        continue;
-                                    }
-                                }
+                                add_fields(property_seg, variable_name);
                             }
                         }
                     }
@@ -209,22 +233,7 @@ fn properties(input: &DeriveInput) -> Vec<Property> {
                         if let Some(property_seg) = type_path.path.segments.first() {
                             let property_type = property_seg.ident.clone();
                             let variable_name = get_variable_name_for_unnamed_field(index, property_type.span());
-                            if property_type == "EntityProperty" {
-                                fields.push(Property::entity(variable_name));
-                                continue;
-                            } else if let PathArguments::AngleBracketed(angle_args) =
-                                &property_seg.arguments
-                            {
-                                if let Some(GenericArgument::Type(inner_type)) =
-                                    angle_args.args.first()
-                                {
-                                    fields.push(Property::normal(
-                                        variable_name,
-                                        inner_type.clone(),
-                                    ));
-                                    continue;
-                                }
-                            }
+                            add_fields(property_seg, &variable_name);
                         }
                     }
                 }
@@ -475,27 +484,29 @@ pub fn new_complete_method(
             Property::Normal(property) => {
                 let field_name = &property.variable_name;
                 let field_type = &property.inner_type;
+                let replicable_property_type = &property.replicable_property_type;
                 let uppercase_variant_name = &property.uppercase_variable_name;
                 if is_replica_tuple_struct {
                     quote! {
-                        Property::<#field_type>::new(#field_name, #enum_name::#uppercase_variant_name as u8)
+                        <#replicable_property_type<#field_type>>::new(#field_name, #enum_name::#uppercase_variant_name as u8)
                     }
                 } else {
                     quote! {
-                        #field_name: Property::<#field_type>::new(#field_name, #enum_name::#uppercase_variant_name as u8)
+                        #field_name: <#replicable_property_type<#field_type>>::new(#field_name, #enum_name::#uppercase_variant_name as u8)
                     }
                 }
             }
             Property::Entity(property) => {
                 let field_name = &property.variable_name;
+                let replicable_entity_property_type = &property.replicable_entity_property_type;
                 let uppercase_variant_name = &property.uppercase_variable_name;
                 if is_replica_tuple_struct {
                     quote! {
-                        EntityProperty::new(#enum_name::#uppercase_variant_name as u8)
+                        <#replicable_entity_property_type>::new(#enum_name::#uppercase_variant_name as u8)
                     }
                 } else {
                     quote! {
-                        #field_name: EntityProperty::new(#enum_name::#uppercase_variant_name as u8)
+                        #field_name: <#replicable_entity_property_type>::new(#enum_name::#uppercase_variant_name as u8)
                     }
                 }
             }
@@ -554,16 +565,18 @@ pub fn read_method(
         let field_name = property.variable_name();
         let new_output_right = match property {
             Property::Normal(property) => {
+                let replicable_property_type = &property.replicable_property_type;
                 let field_type = &property.inner_type;
                 let uppercase_variant_name = &property.uppercase_variable_name;
                 quote! {
-                    let #field_name = Property::<#field_type>::new_read(reader, #enum_name::#uppercase_variant_name as u8)?;
+                    let #field_name = <#replicable_property_type<#field_type>>::new_read(reader, #enum_name::#uppercase_variant_name as u8)?;
                 }
             }
             Property::Entity(property) => {
+                let replicable_entity_property_type = &property.replicable_entity_property_type;
                 let uppercase_variant_name = &property.uppercase_variable_name;
                 quote! {
-                    let #field_name = EntityProperty::new_read(reader, #enum_name::#uppercase_variant_name as u8, converter)?;
+                    let #field_name = <#replicable_entity_property_type>::new_read(reader, #enum_name::#uppercase_variant_name as u8, converter)?;
                 }
             }
         };
@@ -607,24 +620,26 @@ pub fn read_create_update_method(
     for property in properties.iter() {
         let new_output_right = match property {
             Property::Normal(property) => {
+                let replicable_property_type = &property.replicable_property_type;
                 let field_type = &property.inner_type;
                 quote! {
                     {
                         let should_read = bool::de(reader)?;
                         should_read.ser(&mut update_writer);
                         if should_read {
-                            Property::<#field_type>::read_write(reader, &mut update_writer)?;
+                            <#replicable_property_type<#field_type>>::read_write(reader, &mut update_writer)?;
                         }
                     }
                 }
             }
-            Property::Entity(_) => {
+            Property::Entity(property) => {
+                let replicable_entity_property_type = &property.replicable_entity_property_type;
                 quote! {
                     {
                         let should_read = bool::de(reader)?;
                         should_read.ser(&mut update_writer);
                         if should_read {
-                            EntityProperty::read_write(reader, &mut update_writer)?;
+                            <#replicable_entity_property_type>::read_write(reader, &mut update_writer)?;
                         }
                     }
                 }
@@ -659,17 +674,19 @@ fn read_apply_update_method(kind_name: &Ident, properties: &[Property], is_repli
     for (index, property) in properties.iter().enumerate() {
         let field_name = get_field_name(property, index, is_replica_tuple_struct);
         let new_output_right = match property {
-            Property::Normal(_) => {
+            Property::Normal(property) => {
+                let replicable_property_type = &property.replicable_property_type;
                 quote! {
                     if bool::de(reader)? {
-                        Property::read(&mut self.#field_name, reader)?;
+                        #replicable_property_type::read(&mut self.#field_name, reader)?;
                     }
                 }
             }
-            Property::Entity(_) => {
+            Property::Entity(property) => {
+                let replicable_entity_property_type = &property.replicable_entity_property_type;
                 quote! {
                     if bool::de(reader)? {
-                        EntityProperty::read(&mut self.#field_name, reader, converter)?;
+                        <#replicable_entity_property_type>::read(&mut self.#field_name, reader, converter)?;
                     }
                 }
             }
@@ -697,14 +714,16 @@ fn write_method(properties: &[Property], is_replica_tuple_struct: bool) -> Token
     for (index, property) in properties.iter().enumerate() {
         let field_name = get_field_name(property, index, is_replica_tuple_struct);
         let new_output_right = match property {
-            Property::Normal(_) => {
+            Property::Normal(property) => {
+                let replicable_property_type = &property.replicable_property_type;
                 quote! {
-                    Property::write(&self.#field_name, bit_writer);
+                    #replicable_property_type::write(&self.#field_name, bit_writer);
                 }
             }
-            Property::Entity(_) => {
+            Property::Entity(property) => {
+                let replicable_entity_property_type = &property.replicable_entity_property_type;
                 quote! {
-                    EntityProperty::write(&self.#field_name, bit_writer, converter);
+                    <#replicable_entity_property_type>::write(&self.#field_name, bit_writer, converter);
                 }
             }
         };
@@ -731,22 +750,24 @@ fn write_update_method(enum_name: &Ident, properties: &[Property], is_replica_tu
         let field_name = get_field_name(property, index, is_replica_tuple_struct);
         let new_output_right = match property {
             Property::Normal(property) => {
+                let replicable_property_type = &property.replicable_property_type;
                 let uppercase_variant_name = &property.uppercase_variable_name;
                 quote! {
                     if let Some(true) = diff_mask.bit(#enum_name::#uppercase_variant_name as u8) {
                         true.ser(writer);
-                        Property::write(&self.#field_name, writer);
+                        #replicable_property_type::write(&self.#field_name, writer);
                     } else {
                         false.ser(writer);
                     }
                 }
             }
             Property::Entity(property) => {
+                let replicable_entity_property_type = &property.replicable_entity_property_type;
                 let uppercase_variant_name = &property.uppercase_variable_name;
                 quote! {
                     if let Some(true) = diff_mask.bit(#enum_name::#uppercase_variant_name as u8) {
                         true.ser(writer);
-                        EntityProperty::write(&self.#field_name, writer, converter);
+                        <#replicable_entity_property_type>::write(&self.#field_name, writer, converter);
                     } else {
                         false.ser(writer);
                     }
@@ -793,9 +814,7 @@ fn entities_method(properties: &[Property]) -> TokenStream {
         if let Property::Entity(entity_prop) = property {
             let field_name = &entity_prop.variable_name;
             let body_add_right = quote! {
-                if let Some(handle) = self.#field_name.handle() {
-                    output.push(handle);
-                }
+                output.extend(self.#field_name.entities());
             };
             let new_body = quote! {
                 #body

--- a/shared/derive/src/replicate.rs
+++ b/shared/derive/src/replicate.rs
@@ -129,10 +129,17 @@ pub struct EntityProperty {
     pub replicable_entity_property_type: Type,
 }
 
+pub struct NonReplicatedProperty {
+    pub variable_name: Ident,
+    pub field_type: Type,
+}
+
 #[allow(clippy::large_enum_variant)]
 pub enum Property {
     Normal(NormalProperty),
     Entity(EntityProperty),
+    /// We can have some fields that are non replicated. They must implement Default.
+    NonReplicated(NonReplicatedProperty),
 }
 
 pub enum StructType {
@@ -188,10 +195,25 @@ impl Property {
         })
     }
 
+    pub fn nonreplicated(variable_name: Ident, field_type: Type) -> Self {
+        Self::NonReplicated(NonReplicatedProperty {
+            variable_name: variable_name.clone(),
+            field_type,
+        })
+    }
+
+    pub fn is_replicated(&self) -> bool {
+        match self {
+            Self::Normal(_) | Self::Entity(_) => true,
+            Self::NonReplicated(_) => false
+        }
+    }
+
     pub fn variable_name(&self) -> &Ident {
         match self {
             Self::Normal(property) => &property.variable_name,
             Self::Entity(property) => &property.variable_name,
+            Self::NonReplicated(property) => &property.variable_name,
         }
     }
 
@@ -199,6 +221,7 @@ impl Property {
         match self {
             Self::Normal(property) => &property.uppercase_variable_name,
             Self::Entity(property) => &property.uppercase_variable_name,
+            Self::NonReplicated(_) => panic!("Unused for non-replicated properties")
         }
     }
 }
@@ -209,7 +232,7 @@ impl Property {
 fn properties(input: &DeriveInput) -> Vec<Property> {
     let mut fields = Vec::new();
 
-    let mut add_fields = |property_seg: &PathSegment, variable_name: &Ident| {
+    let mut add_fields = |property_seg: &PathSegment, variable_name: &Ident, field_type: &Type| {
         let property_type = &property_seg.ident;
         // EntityProperty
         if property_type == "EntityProperty" {
@@ -236,6 +259,8 @@ fn properties(input: &DeriveInput) -> Vec<Property> {
                     ));
                 }
             }
+        } else {
+            fields.push(Property::nonreplicated(variable_name.clone(), field_type.clone()));
         }
     };
 
@@ -246,7 +271,7 @@ fn properties(input: &DeriveInput) -> Vec<Property> {
                     if let Some(variable_name) = &field.ident {
                         if let Type::Path(type_path) = &field.ty {
                             if let Some(property_seg) = type_path.path.segments.first() {
-                                add_fields(property_seg, variable_name);
+                                add_fields(property_seg, variable_name, &field.ty);
                             }
                         }
                     }
@@ -258,7 +283,7 @@ fn properties(input: &DeriveInput) -> Vec<Property> {
                         if let Some(property_seg) = type_path.path.segments.first() {
                             let property_type = property_seg.ident.clone();
                             let variable_name = get_variable_name_for_unnamed_field(index, property_type.span());
-                            add_fields(property_seg, &variable_name);
+                            add_fields(property_seg, &variable_name, &field.ty);
                         }
                     }
                 }
@@ -329,7 +354,7 @@ fn property_enum(enum_name: &Ident, properties: &[Property]) -> TokenStream {
 
     let mut variant_list = quote! {};
 
-    for (index, property) in properties.iter().enumerate() {
+    for (index, property) in properties.iter().filter(|p| p.is_replicated()).enumerate() {
         let index = syn::Index::from(index);
         let uppercase_variant_name = property.uppercase_variable_name();
 
@@ -414,6 +439,7 @@ fn clone_method(
                 };
                 entity_property_output = new_output_result;
             }
+            _ => {}
         };
     }
 
@@ -434,7 +460,7 @@ fn mirror_method(
 ) -> TokenStream {
     let mut output = quote! {};
 
-    for (index, property) in properties.iter().enumerate() {
+    for (index, property) in properties.iter().filter(|p| p.is_replicated()).enumerate() {
         let field_name = get_field_name(property, index, struct_type);
         let new_output_right = quote! {
             self.#field_name.mirror(&replica.#field_name);
@@ -458,7 +484,7 @@ fn mirror_method(
 fn set_mutator_method(properties: &[Property], struct_type: &StructType) -> TokenStream {
     let mut output = quote! {};
 
-    for (index, property) in properties.iter().enumerate() {
+    for (index, property) in properties.iter().filter(|p| p.is_replicated()).enumerate() {
         let field_name = get_field_name(property, index, struct_type);
         let new_output_right = quote! {
                 self.#field_name.set_mutator(mutator);
@@ -499,7 +525,7 @@ pub fn new_complete_method(
                 };
                 args = new_output_result;
             }
-            Property::Entity(_) => {
+            Property::Entity(_) | Property::NonReplicated(_) => {
                 continue;
             }
         };
@@ -540,6 +566,23 @@ pub fn new_complete_method(
                     StructType::TupleStruct => {
                         quote! {
                             <#replicable_entity_property_type>::new(#enum_name::#uppercase_variant_name as u8)
+                        }
+                    }
+                    _ => {quote!{}}
+                }
+            }
+            Property::NonReplicated(property) => {
+                let field_name = &property.variable_name;
+                let field_type = &property.field_type;
+                match *struct_type {
+                    StructType::Struct =>  {
+                        quote! {
+                             #field_name: <#field_type>::default()
+                        }
+                    }
+                    StructType::TupleStruct => {
+                        quote! {
+                            <#field_type>::default()
                         }
                     }
                     _ => {quote!{}}
@@ -622,6 +665,13 @@ pub fn read_method(
                     let #field_name = <#replicable_entity_property_type>::new_read(reader, #enum_name::#uppercase_variant_name as u8, converter)?;
                 }
             }
+            Property::NonReplicated(property) => {
+                let field_name = &property.variable_name;
+                let field_type = &property.field_type;
+                quote! {
+                    let #field_name = <#field_type>::default();
+                }
+            }
         };
 
         let new_output_result = quote! {
@@ -695,6 +745,7 @@ pub fn read_create_update_method(
                     }
                 }
             }
+            Property::NonReplicated(_) => {continue;}
         };
 
         let new_output_result = quote! {
@@ -745,6 +796,7 @@ fn read_apply_update_method(
                     }
                 }
             }
+            Property::NonReplicated(_) => {continue;}
         };
 
         let new_output_result = quote! {
@@ -781,6 +833,7 @@ fn write_method(properties: &[Property], struct_type: &StructType) -> TokenStrea
                     <#replicable_entity_property_type>::write(&self.#field_name, bit_writer, converter);
                 }
             }
+            Property::NonReplicated(_) => {continue;}
         };
 
         let new_output_result = quote! {
@@ -832,6 +885,7 @@ fn write_update_method(
                     }
                 }
             }
+            Property::NonReplicated(_) => {continue;}
         };
 
         let new_output_result = quote! {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -74,7 +74,7 @@ pub use protocol::{
     entity_handle::EntityHandle,
     entity_property::{
         EntityConverter, EntityHandleConverter, EntityProperty, FakeEntityConverter,
-        NetEntityConverter, NetEntityHandleConverter,
+        NetEntityConverter, NetEntityHandleConverter, VecDequeEntityProperty,
     },
     net_entity::NetEntity,
     property::Property,
@@ -86,6 +86,7 @@ pub use protocol::{
         ReplicaDynRefWrapper, ReplicaMutTrait, ReplicaMutWrapper, ReplicaRefTrait,
         ReplicaRefWrapper,
     },
+    replicable_property::{ReplicableProperty, ReplicableEntityProperty},
     replicate::{Replicate, ReplicateSafe},
 };
 

--- a/shared/src/protocol/entity_property.rs
+++ b/shared/src/protocol/entity_property.rs
@@ -132,7 +132,8 @@ impl ReplicableEntityProperty for EntityProperty {
 // to be alerted whenever anything changes in the VecDeque
 
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "bevy_support", derive(Reflect))]
+// Reflect not supported for VecDeque
+// #[cfg_attr(feature = "bevy_support", derive(Reflect))]
 pub struct VecDequeEntityProperty(Property<VecDeque<EntityHandle>>);
 
 impl VecDequeEntityProperty {
@@ -152,6 +153,16 @@ impl VecDequeEntityProperty {
             queue.push_back(new_handle);
         });
         *self.0 = queue;
+    }
+
+    pub fn push_front<E: Copy + Eq + Hash>(&mut self, handler: &dyn EntityHandleConverter<E>, entity: &E) {
+        let new_handle = handler.entity_to_handle(entity);
+        self.0.push_front(new_handle);
+    }
+
+    pub fn push_back<E: Copy + Eq + Hash>(&mut self, handler: &dyn EntityHandleConverter<E>, entity: &E) {
+        let new_handle = handler.entity_to_handle(entity);
+        self.0.push_back(new_handle);
     }
 }
 

--- a/shared/src/protocol/entity_property.rs
+++ b/shared/src/protocol/entity_property.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::hash::Hash;
+use std::ops::{Deref, DerefMut};
 
 use naia_serde::{BitReader, BitWrite, BitWriter, Serde, SerdeErr, UnsignedVariableInteger};
 
@@ -231,6 +232,21 @@ impl ReplicableEntityProperty for VecDequeEntityProperty {
         self.0.set_mutator(mutator)
     }
 }
+
+impl Deref for VecDequeEntityProperty {
+    type Target = Property<VecDeque<EntityHandle>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for VecDequeEntityProperty{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 
 
 pub trait EntityHandleConverter<E: Copy + Eq + Hash> {

--- a/shared/src/protocol/mod.rs
+++ b/shared/src/protocol/mod.rs
@@ -10,5 +10,6 @@ pub mod property;
 pub mod property_mutate;
 pub mod protocol_io;
 pub mod protocolize;
+pub mod replicable_property;
 pub mod replica_ref;
 pub mod replicate;

--- a/shared/src/protocol/replicable_property.rs
+++ b/shared/src/protocol/replicable_property.rs
@@ -1,0 +1,88 @@
+use naia_serde::{BitReader, BitWrite, BitWriter, Serde, SerdeErr};
+use crate::{EntityHandle, NetEntityHandleConverter, PropertyMutator};
+
+
+/// Trait for types that can be replicated and don't contain entity-related data
+pub trait ReplicableProperty {
+    /// Inner type that needs to be replicated
+    type Inner: Serde;
+
+    /// Create a new Property
+    fn new(value: Self::Inner, mutator_index: u8) -> Self;
+
+    /// Set value to the value of another Property, queues for update if value
+    /// changes
+    fn mirror(&mut self, other: &Self);
+
+    // Serialization / deserialization
+
+    /// Writes contained value into outgoing byte stream
+    fn write(&self, writer: &mut dyn BitWrite);
+
+    /// Given a cursor into incoming packet data, initializes the Property with
+    /// the synced value
+    fn new_read(reader: &mut BitReader, mutator_index: u8) -> Result<Self, SerdeErr> where Self: Sized;
+
+    /// Reads from a stream and immediately writes to a stream
+    /// Used to buffer updates for later
+    fn read_write(reader: &mut BitReader, writer: &mut BitWriter) -> Result<(), SerdeErr>;
+
+    /// Given a cursor into incoming packet data, updates the Property with the
+    /// synced value
+    fn read(&mut self, reader: &mut BitReader) -> Result<(), SerdeErr>;
+
+    // Comparison
+
+    // TODO: use partial eq instead?
+    /// Compare to another property
+    fn equals(&self, other: &Self) -> bool;
+
+    // Internal
+
+    /// Set an PropertyMutator to track changes to the Property
+    fn set_mutator(&mut self, mutator: &PropertyMutator);
+}
+
+
+/// Trait for types that can be replicated and contain entity-related data
+pub trait ReplicableEntityProperty {
+
+    /// Create a new EntityProperty
+    fn new(mutator_index: u8) -> Self;
+
+    /// Set value to the value of another Property, queues for update if value
+    /// changes
+    fn mirror(&mut self, other: &Self);
+
+    // Serialization / deserialization
+
+    /// Writes contained value into outgoing byte stream
+    fn write(&self, writer: &mut dyn BitWrite, converter: &dyn NetEntityHandleConverter);
+
+    /// Given a cursor into incoming packet data, initializes the Property with
+    /// the synced value
+    fn new_read(reader: &mut BitReader, mutator_index: u8, converter: &dyn NetEntityHandleConverter) -> Result<Self, SerdeErr> where Self: Sized;
+
+    /// Reads from a stream and immediately writes to a stream
+    /// Used to buffer updates for later
+    fn read_write(reader: &mut BitReader, writer: &mut BitWriter) -> Result<(), SerdeErr>;
+
+    /// Given a cursor into incoming packet data, updates the Property with the
+    /// synced value
+    fn read(&mut self, reader: &mut BitReader, converter: &dyn NetEntityHandleConverter,) -> Result<(), SerdeErr>;
+
+    // Comparison
+
+    // TODO: use partial eq instead?
+    /// Compare to another property
+    fn equals(&self, other: &Self) -> bool;
+
+    // Entities
+
+    fn entities(&self) -> Vec<EntityHandle>;
+
+    // Internal
+
+    /// Set an PropertyMutator to track changes to the Property
+    fn set_mutator(&mut self, mutator: &PropertyMutator);
+}

--- a/shared/tests/derive_replicate.rs
+++ b/shared/tests/derive_replicate.rs
@@ -1,26 +1,45 @@
 mod some_protocol {
-    use super::some_replica::StringHolder;
+    use super::some_named_replica::NamedStringHolder;
+    use super::some_tuple_replica::TupleStringHolder;
     use naia_shared::Protocolize;
 
     #[derive(Protocolize)]
     pub enum SomeProtocol {
-        StringHolder(StringHolder),
+        NamedStringHolder(NamedStringHolder),
+        TupleStringHolder(TupleStringHolder)
     }
 }
 
-mod some_replica {
+mod some_named_replica {
     use naia_shared::{Property, Replicate};
 
     #[derive(Replicate)]
     #[protocol_path = "super::some_protocol::SomeProtocol"]
-    pub struct StringHolder {
+    pub struct NamedStringHolder {
         pub string_1: Property<String>,
         pub string_2: Property<String>,
     }
 
-    impl StringHolder {
+    impl NamedStringHolder {
         pub fn new(string_1: &str, string_2: &str) -> Self {
-            return StringHolder::new_complete(string_1.to_string(), string_2.to_string());
+            return NamedStringHolder::new_complete(string_1.to_string(), string_2.to_string());
+        }
+    }
+}
+
+mod some_tuple_replica {
+    use naia_shared::{Property, Replicate};
+
+    #[derive(Replicate)]
+    #[protocol_path = "super::some_protocol::SomeProtocol"]
+    pub struct TupleStringHolder(
+        pub Property<String>,
+        pub Property<String>,
+    );
+
+    impl TupleStringHolder {
+        pub fn new(string_1: &str, string_2: &str) -> Self {
+            return TupleStringHolder::new_complete(string_1.to_string(), string_2.to_string());
         }
     }
 }
@@ -31,14 +50,15 @@ use naia_shared::{
 };
 
 use some_protocol::SomeProtocol;
-use some_replica::StringHolder;
+use some_named_replica::NamedStringHolder;
+use some_tuple_replica::TupleStringHolder;
 
 #[test]
-fn read_write_protocol() {
+fn read_write_named_replica() {
     // Write
     let mut writer = BitWriter::new();
 
-    let in_1 = SomeProtocol::StringHolder(StringHolder::new("hello world", "goodbye world"));
+    let in_1 = SomeProtocol::NamedStringHolder(NamedStringHolder::new("hello world", "goodbye world"));
 
     in_1.write(&mut writer, &FakeEntityConverter);
 
@@ -51,12 +71,40 @@ fn read_write_protocol() {
     let out_1 = SomeProtocol::read(&mut reader, &FakeEntityConverter)
         .expect("should deserialize correctly");
 
-    let typed_in_1 = in_1.cast_ref::<StringHolder>().unwrap();
-    let typed_out_1 = out_1.cast_ref::<StringHolder>().unwrap();
+    let typed_in_1 = in_1.cast_ref::<NamedStringHolder>().unwrap();
+    let typed_out_1 = out_1.cast_ref::<NamedStringHolder>().unwrap();
     assert!(typed_in_1.string_1.equals(&typed_out_1.string_1));
     assert!(typed_in_1.string_2.equals(&typed_out_1.string_2));
     assert_eq!(*typed_in_1.string_1, "hello world".to_string());
     assert_eq!(*typed_in_1.string_2, "goodbye world".to_string());
     assert_eq!(*typed_out_1.string_1, "hello world".to_string());
     assert_eq!(*typed_out_1.string_2, "goodbye world".to_string());
+}
+
+#[test]
+fn read_write_tuple_replica() {
+    // Write
+    let mut writer = BitWriter::new();
+
+    let in_1 = SomeProtocol::TupleStringHolder(TupleStringHolder::new("hello world", "goodbye world"));
+
+    in_1.write(&mut writer, &FakeEntityConverter);
+
+    let (buffer_length, buffer) = writer.flush();
+
+    // Read
+
+    let mut reader = BitReader::new(&buffer[..buffer_length]);
+
+    let out_1 = SomeProtocol::read(&mut reader, &FakeEntityConverter)
+        .expect("should deserialize correctly");
+
+    let typed_in_1 = in_1.cast_ref::<TupleStringHolder>().unwrap();
+    let typed_out_1 = out_1.cast_ref::<TupleStringHolder>().unwrap();
+    assert!(typed_in_1.0.equals(&typed_out_1.0));
+    assert!(typed_in_1.1.equals(&typed_out_1.1));
+    assert_eq!(*typed_in_1.0, "hello world".to_string());
+    assert_eq!(*typed_in_1.1, "goodbye world".to_string());
+    assert_eq!(*typed_out_1.0, "hello world".to_string());
+    assert_eq!(*typed_out_1.1, "goodbye world".to_string());
 }

--- a/shared/tests/derive_replicate.rs
+++ b/shared/tests/derive_replicate.rs
@@ -191,13 +191,13 @@ fn read_write_entity_replica() {
     assert_eq!(typed_in_1.entity_1.get(&TestEntityConverter).unwrap(), 1);
     assert_eq!(typed_in_1.entity_1.handle().unwrap().to_u64(), 1);
 
-    assert_eq!(typed_in_1.vec_entity_1.get(&TestEntityConverter), VecDeque::<Option<u64>>::from(
-        [Some(2), Some(3)]
+    assert_eq!(typed_in_1.vec_entity_1.get(&TestEntityConverter), VecDeque::<u64>::from(
+        [2, 3]
     ));
 
     assert_eq!(typed_out_1.entity_1.get(&TestEntityConverter).unwrap(), 1);
     assert_eq!(typed_out_1.entity_1.handle().unwrap().to_u64(), 1);
-    assert_eq!(typed_in_1.vec_entity_1.get(&TestEntityConverter), VecDeque::<Option<u64>>::from(
-        [Some(2), Some(3)]
+    assert_eq!(typed_in_1.vec_entity_1.get(&TestEntityConverter), VecDeque::<u64>::from(
+        [2, 3]
     ));
 }

--- a/shared/tests/derive_replicate.rs
+++ b/shared/tests/derive_replicate.rs
@@ -36,11 +36,14 @@ mod some_named_replica {
     pub struct NamedStringHolder {
         pub string_1: Property<String>,
         pub string_2: Property<String>,
+        pub extra_string: String,
     }
 
     impl NamedStringHolder {
-        pub fn new(string_1: &str, string_2: &str) -> Self {
-            return NamedStringHolder::new_complete(string_1.to_string(), string_2.to_string());
+        pub fn new(string_1: &str, string_2: &str, extra_string: &str) -> Self {
+            let mut res =  NamedStringHolder::new_complete(string_1.to_string(), string_2.to_string());
+            res.extra_string = extra_string.to_string();
+            res
         }
     }
 }
@@ -50,14 +53,13 @@ mod some_tuple_replica {
 
     #[derive(Replicate)]
     #[protocol_path = "super::some_protocol::SomeProtocol"]
-    pub struct TupleStringHolder(
-        pub Property<String>,
-        pub Property<String>,
-    );
+    pub struct TupleStringHolder(pub Property<String>, pub Property<String>, pub String);
 
     impl TupleStringHolder {
-        pub fn new(string_1: &str, string_2: &str) -> Self {
-            return TupleStringHolder::new_complete(string_1.to_string(), string_2.to_string());
+        pub fn new(string_1: &str, string_2: &str, extra_string: &str) -> Self {
+            let mut res =  TupleStringHolder::new_complete(string_1.to_string(), string_2.to_string());
+            res.2 = extra_string.to_string();
+            res
         }
     }
 }
@@ -94,7 +96,7 @@ fn read_write_named_replica() {
     // Write
     let mut writer = BitWriter::new();
 
-    let in_1 = SomeProtocol::NamedStringHolder(NamedStringHolder::new("hello world", "goodbye world"));
+    let in_1 = SomeProtocol::NamedStringHolder(NamedStringHolder::new("hello world", "goodbye world", "extra"));
 
     in_1.write(&mut writer, &FakeEntityConverter);
 
@@ -113,8 +115,10 @@ fn read_write_named_replica() {
     assert!(typed_in_1.string_2.equals(&typed_out_1.string_2));
     assert_eq!(*typed_in_1.string_1, "hello world".to_string());
     assert_eq!(*typed_in_1.string_2, "goodbye world".to_string());
+    assert_eq!(*typed_in_1.extra_string, "extra".to_string());
     assert_eq!(*typed_out_1.string_1, "hello world".to_string());
     assert_eq!(*typed_out_1.string_2, "goodbye world".to_string());
+    assert_eq!(*typed_out_1.extra_string, "".to_string());
 }
 
 #[test]
@@ -144,7 +148,7 @@ fn read_write_tuple_replica() {
     // Write
     let mut writer = BitWriter::new();
 
-    let in_1 = SomeProtocol::TupleStringHolder(TupleStringHolder::new("hello world", "goodbye world"));
+    let in_1 = SomeProtocol::TupleStringHolder(TupleStringHolder::new("hello world", "goodbye world", "extra"));
 
     in_1.write(&mut writer, &FakeEntityConverter);
 
@@ -163,8 +167,10 @@ fn read_write_tuple_replica() {
     assert!(typed_in_1.1.equals(&typed_out_1.1));
     assert_eq!(*typed_in_1.0, "hello world".to_string());
     assert_eq!(*typed_in_1.1, "goodbye world".to_string());
+    assert_eq!(*typed_in_1.2, "extra".to_string());
     assert_eq!(*typed_out_1.0, "hello world".to_string());
     assert_eq!(*typed_out_1.1, "goodbye world".to_string());
+    assert_eq!(*typed_out_1.2, "".to_string());
 }
 
 #[test]


### PR DESCRIPTION
# Context

I created this PR for game that I am working on, where I was having issues with the current replicate.

List of changes.
Uncontroversial:
- can derive Replicate on unit structs
- can derive Replicate on tuple structs

Controversial:
- can add extra-fields in Replicated structs that won't be replicated (to put some server-specific or client-specific data in the component, for instance)
- created two traits `ReplicableProperty` and `ReplicableEntityProperty` for 'stuff' that can act as a `Property` or `EntityProperty`. The main goal was to be able to replicate `VecDeque<EntityProperty>` or something similar; I was able to replicate properly but ran into some other errors so I ended up not using it right now.


Not everything in this PR can be kept; it's just an amalgalm of changes I made in my fork related to Replicate.