### PR TITLE
Add broadcast_messages to all clients

### DIFF
--- a/adapters/bevy/server/src/server.rs
+++ b/adapters/bevy/server/src/server.rs
@@ -72,6 +72,17 @@ impl<'world, 'state, P: Protocolize, C: ChannelIndex> Server<'world, 'state, P, 
         self.server.send_message(user_key, channel, message)
     }
 
+    /// Sends a message to all connected users using a given channel
+    pub fn broadcast_message<R: ReplicateSafe<P>>(
+        &mut self,
+        channel: C,
+        message: &R,
+    ) {
+        self.server.user_keys().iter().for_each(|user_key| {
+            self.send_message(user_key, channel.clone(), message)
+        })
+    }
+
     //// Updates ////
 
     pub fn scope_checks(&self) -> Vec<(RoomKey, UserKey, Entity)> {

--- a/adapters/bevy/server/src/server.rs
+++ b/adapters/bevy/server/src/server.rs
@@ -83,6 +83,19 @@ impl<'world, 'state, P: Protocolize, C: ChannelIndex> Server<'world, 'state, P, 
         })
     }
 
+    /// Sends a message to all connected users in a given Room using a given channel
+    pub fn broadcast_message_to_room<R: ReplicateSafe<P>>(
+        &mut self,
+        channel: C,
+        message: &R,
+        room_key: &RoomKey,
+    ) {
+        let user_keys: Vec<UserKey> = self.room(room_key).user_keys().cloned().collect();
+        user_keys.iter().for_each(|user_key| {
+            self.send_message(user_key, channel.clone(), message)
+        });
+    }
+
     //// Updates ////
 
     pub fn scope_checks(&self) -> Vec<(RoomKey, UserKey, Entity)> {

--- a/adapters/bevy/server/src/server.rs
+++ b/adapters/bevy/server/src/server.rs
@@ -73,14 +73,11 @@ impl<'world, 'state, P: Protocolize, C: ChannelIndex> Server<'world, 'state, P, 
     }
 
     /// Sends a message to all connected users using a given channel
-    pub fn broadcast_message<R: ReplicateSafe<P>>(
-        &mut self,
-        channel: C,
-        message: &R,
-    ) {
-        self.server.user_keys().iter().for_each(|user_key| {
-            self.send_message(user_key, channel.clone(), message)
-        })
+    pub fn broadcast_message<R: ReplicateSafe<P>>(&mut self, channel: C, message: &R) {
+        self.server
+            .user_keys()
+            .iter()
+            .for_each(|user_key| self.send_message(user_key, channel.clone(), message))
     }
 
     /// Sends a message to all connected users in a given Room using a given channel
@@ -91,9 +88,9 @@ impl<'world, 'state, P: Protocolize, C: ChannelIndex> Server<'world, 'state, P, 
         room_key: &RoomKey,
     ) {
         let user_keys: Vec<UserKey> = self.room(room_key).user_keys().cloned().collect();
-        user_keys.iter().for_each(|user_key| {
-            self.send_message(user_key, channel.clone(), message)
-        });
+        user_keys
+            .iter()
+            .for_each(|user_key| self.send_message(user_key, channel.clone(), message));
     }
 
     //// Updates ////

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -125,7 +125,7 @@ impl<'s, P: Protocolize, E: Copy + Eq + Hash + Send + Sync, C: ChannelIndex> Roo
     }
 
     /// Returns an iterator of the [`UserKey`] for Users that belong in the [`Room`]
-    pub fn user_keys(&self) -> impl Iterator<Item=&UserKey> {
+    pub fn user_keys(&self) -> impl Iterator<Item = &UserKey> {
         self.server.room_user_keys(&self.key)
     }
 
@@ -182,7 +182,7 @@ impl<'s, P: Protocolize, E: Copy + Eq + Hash + Send + Sync, C: ChannelIndex> Roo
     }
 
     /// Returns an iterator of the [`UserKey`] for Users that belong in the [`Room`]
-    pub fn user_keys(&self) -> impl Iterator<Item=&UserKey> {
+    pub fn user_keys(&self) -> impl Iterator<Item = &UserKey> {
         self.server.room_user_keys(&self.key)
     }
 

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -124,6 +124,11 @@ impl<'s, P: Protocolize, E: Copy + Eq + Hash + Send + Sync, C: ChannelIndex> Roo
         self.server.room_users_count(&self.key)
     }
 
+    /// Returns an iterator of the [`UserKey`] for Users that belong in the [`Room`]
+    pub fn user_keys(&self) -> impl Iterator<Item=&UserKey> {
+        self.server.room_user_keys(&self.key)
+    }
+
     // Entities
 
     pub fn has_entity(&self, entity: &E) -> bool {
@@ -174,6 +179,11 @@ impl<'s, P: Protocolize, E: Copy + Eq + Hash + Send + Sync, C: ChannelIndex> Roo
 
     pub fn users_count(&self) -> usize {
         self.server.room_users_count(&self.key)
+    }
+
+    /// Returns an iterator of the [`UserKey`] for Users that belong in the [`Room`]
+    pub fn user_keys(&self) -> impl Iterator<Item=&UserKey> {
+        self.server.room_user_keys(&self.key)
     }
 
     // Entities

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -5,8 +5,6 @@ use std::{
     panic,
     sync::{Arc, RwLock},
 };
-use std::collections::hash_set::Iter;
-use std::collections::HashSet;
 
 #[cfg(feature = "bevy_support")]
 use bevy_ecs::prelude::Resource;
@@ -731,7 +729,7 @@ impl<P: Protocolize, E: Copy + Eq + Hash + Send + Sync, C: ChannelIndex> Server<
     }
 
     /// Returns an iterator of the [`UserKey`] for Users that belong in the Room
-    pub(crate) fn room_user_keys(&self, room_key: &RoomKey) -> impl Iterator<Item=&UserKey> {
+    pub(crate) fn room_user_keys(&self, room_key: &RoomKey) -> impl Iterator<Item = &UserKey> {
         let iter = if let Some(room) = self.rooms.get(room_key) {
             Some(room.user_keys())
         } else {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -5,6 +5,8 @@ use std::{
     panic,
     sync::{Arc, RwLock},
 };
+use std::collections::hash_set::Iter;
+use std::collections::HashSet;
 
 #[cfg(feature = "bevy_support")]
 use bevy_ecs::prelude::Resource;
@@ -726,6 +728,16 @@ impl<P: Protocolize, E: Copy + Eq + Hash + Send + Sync, C: ChannelIndex> Server<
         if let Some(room) = self.rooms.get_mut(room_key) {
             room.subscribe_user(user_key);
         }
+    }
+
+    /// Returns an iterator of the [`UserKey`] for Users that belong in the Room
+    pub(crate) fn room_user_keys(&self, room_key: &RoomKey) -> impl Iterator<Item=&UserKey> {
+        let iter = if let Some(room) = self.rooms.get(room_key) {
+            Some(room.user_keys())
+        } else {
+            None
+        };
+        iter.into_iter().flatten()
     }
 
     /// Removes a User from a Room


### PR DESCRIPTION
# Context

I needed a way to broadcast a message to all users in the same room as a given user.

Also:
- do every users need to belong in a room, or can users can connect without having a room?
- it might be worth adding an `Option<RoomKey>` to `UserRef` or `User` so I can easily get the room that user belongs to. Right now I have to do the bookkeeping myself. Would you be interested in a PR for that?