### PR TITLE
Added broadcast_message_scoped to allow sending messages only to users with a specific entity in their scope

### DIFF
--- a/adapters/bevy/server/src/server.rs
+++ b/adapters/bevy/server/src/server.rs
@@ -57,6 +57,10 @@ impl<'w> Server<'w> {
         self.server.broadcast_message::<C, M>(message);
     }
 
+    pub fn broadcast_message_scoped<C: Channel, M: Message>(&mut self, entity: &Entity, message: &M) {
+        self.server.broadcast_message_scoped::<C, M>(entity, message);
+    }
+
     pub fn receive_tick_buffer_messages(&mut self, tick: &Tick) -> TickBufferMessages {
         self.server.receive_tick_buffer_messages(tick)
     }

--- a/server/src/world/entity_scope_map.rs
+++ b/server/src/world/entity_scope_map.rs
@@ -20,13 +20,18 @@ impl<E: Copy + Eq + Hash> EntityScopeMap<E> {
         }
     }
 
-    pub fn get(&self, user_key: &UserKey, entity: &E) -> Option<&bool> {
+    pub fn get(&self, user_key: &UserKey, entity: &E) -> bool {
         let key = (*user_key, *entity);
 
-        self.main_map.get(&key)
+        self.main_map.get(&key).map(|k| *k).unwrap_or(false)
     }
 
     pub fn insert(&mut self, user_key: UserKey, entity: E, in_scope: bool) {
+        if self.main_map.contains_key(&(user_key, entity)) {
+            // Only need to update scope status
+            self.main_map.insert((user_key, entity), in_scope);
+            return;
+        }
         self.entities_of_user
             .entry(user_key)
             .or_insert_with(|| HashSet::new());


### PR DESCRIPTION
@connorcarpenter I noticed it didn't seem possible to broadcast a message to users with a specific entity in their scope. This PR is my attempt to add that feature.