### PR TITLE
Fix: CommandHistory replay is reversed.

### DIFF
--- a/client/src/command_history.rs
+++ b/client/src/command_history.rs
@@ -26,6 +26,7 @@ impl<T: Clone> CommandHistory<T> {
             output.push((*tick, command.clone()));
         }
 
+        output.reverse();
         output
     }
 

--- a/client/src/command_history.rs
+++ b/client/src/command_history.rs
@@ -65,3 +65,22 @@ impl<T: Clone> CommandHistory<T> {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CommandHistory;
+    #[test]
+    fn replay_order() {
+        let mut command_history: CommandHistory<&str> = CommandHistory::default();
+
+        command_history.insert(1u16, "turn left!");
+        command_history.insert(2u16, "go straight!");
+
+        let commands = command_history.replays(&0u16);
+
+        assert_eq!(commands[0].0, 1u16);
+        assert_eq!(commands[0].1, "turn left!");
+        assert_eq!(commands[1].0, 2u16);
+        assert_eq!(commands[1].1, "go straight!");
+    }
+}


### PR DESCRIPTION
I am attempting to implement a directional movement feature with naia.
However, I've encountered an issue where the order of the CommandHistory replay is reversed.
I believe this needs to be fixed.

insertion order:

- 'turn left'
- 'go straight'.

expected order:

- 'turn left'
- 'go straight'.

actual replay order (reversed):
- 'go straight'
- 'turn left'