### PR TITLE
Update to Bevy 0.11

### DIFF
--- a/adapters/bevy/client/Cargo.toml
+++ b/adapters/bevy/client/Cargo.toml
@@ -19,5 +19,5 @@ transport_udp = [ "naia-client/transport_udp" ]
 [dependencies]
 naia-client = { version = "0.21.0", path = "../../../client", features = ["bevy_support", "wbindgen"] }
 naia-bevy-shared = { version = "0.21", path = "../shared" }
-bevy_app = { version = "0.10", default-features=false }
-bevy_ecs = { version = "0.10", default-features=false }
+bevy_app = { version = "0.11", default-features=false }
+bevy_ecs = { version = "0.11", default-features=false }

--- a/adapters/bevy/client/src/commands.rs
+++ b/adapters/bevy/client/src/commands.rs
@@ -59,7 +59,7 @@ impl DuplicateComponents {
 }
 
 impl BevyCommand for DuplicateComponents {
-    fn write(self, world: &mut World) {
+    fn apply(self, world: &mut World) {
         WorldMutType::<Entity>::duplicate_components(
             &mut world.proxy_mut(),
             &self.mutable_entity,

--- a/adapters/bevy/client/src/events.rs
+++ b/adapters/bevy/client/src/events.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, collections::HashMap};
 
-use bevy_ecs::entity::Entity;
+use bevy_ecs::{entity::Entity, prelude::Event};
 
 use naia_client::{Events, NaiaClientError};
 
@@ -9,18 +9,23 @@ use naia_bevy_shared::{
 };
 
 // ConnectEvent
+#[derive(Event)]
 pub struct ConnectEvent;
 
 // DisconnectEvent
+#[derive(Event)]
 pub struct DisconnectEvent;
 
 // RejectEvent
+#[derive(Event)]
 pub struct RejectEvent;
 
 // ErrorEvent
+#[derive(Event)]
 pub struct ErrorEvent(pub NaiaClientError);
 
 // MessageEvents
+#[derive(Event)]
 pub struct MessageEvents {
     inner: HashMap<ChannelKind, HashMap<MessageKind, Vec<MessageContainer>>>,
 }
@@ -57,18 +62,23 @@ impl MessageEvents {
 }
 
 // ClientTickEvent
+#[derive(Event)]
 pub struct ClientTickEvent(pub Tick);
 
 // ServerTickEvent
+#[derive(Event)]
 pub struct ServerTickEvent(pub Tick);
 
 // SpawnEntityEvent
+#[derive(Event)]
 pub struct SpawnEntityEvent(pub Entity);
 
 // DespawnEntityEvent
+#[derive(Event)]
 pub struct DespawnEntityEvent(pub Entity);
 
 // InsertComponentEvent
+#[derive(Event)]
 pub struct InsertComponentEvents {
     inner: HashMap<ComponentKind, Vec<Entity>>,
 }
@@ -88,6 +98,7 @@ impl InsertComponentEvents {
 }
 
 // UpdateComponentEvents
+#[derive(Event)]
 pub struct UpdateComponentEvents {
     inner: HashMap<ComponentKind, Vec<(Tick, Entity)>>,
 }
@@ -108,6 +119,7 @@ impl UpdateComponentEvents {
 }
 
 // RemoveComponentEvents
+#[derive(Event)]
 pub struct RemoveComponentEvents {
     inner: HashMap<ComponentKind, Vec<(Entity, Box<dyn Replicate>)>>,
 }

--- a/adapters/bevy/client/src/plugin.rs
+++ b/adapters/bevy/client/src/plugin.rs
@@ -1,7 +1,7 @@
 use std::{ops::DerefMut, sync::Mutex};
 
-use bevy_app::{App, Plugin as PluginType};
-use bevy_ecs::{entity::Entity, schedule::IntoSystemConfig};
+use bevy_app::{App, Plugin as PluginType, Update};
+use bevy_ecs::{entity::Entity, schedule::IntoSystemConfigs};
 
 use naia_bevy_shared::{BeforeReceiveEvents, Protocol, SharedPlugin};
 use naia_client::{Client, ClientConfig};
@@ -54,7 +54,7 @@ impl PluginType for Plugin {
 
         app
             // SHARED PLUGIN //
-            .add_plugin(SharedPlugin)
+            .add_plugins(SharedPlugin)
             // RESOURCES //
             .insert_resource(client)
             // EVENTS //
@@ -71,6 +71,6 @@ impl PluginType for Plugin {
             .add_event::<UpdateComponentEvents>()
             .add_event::<RemoveComponentEvents>()
             // SYSTEMS //
-            .add_system(before_receive_events.in_set(BeforeReceiveEvents));
+            .add_systems(Update, before_receive_events.in_set(BeforeReceiveEvents));
     }
 }

--- a/adapters/bevy/server/Cargo.toml
+++ b/adapters/bevy/server/Cargo.toml
@@ -19,5 +19,5 @@ transport_udp = [ "naia-server/transport_udp" ]
 [dependencies]
 naia-server = { version = "0.21", path = "../../../server", features = ["bevy_support"] }
 naia-bevy-shared = { version = "0.21", path = "../shared" }
-bevy_app = { version = "0.10", default-features=false }
-bevy_ecs = { version = "0.10", default-features=false }
+bevy_app = { version = "0.11", default-features=false }
+bevy_ecs = { version = "0.11", default-features=false }

--- a/adapters/bevy/server/src/events.rs
+++ b/adapters/bevy/server/src/events.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, collections::HashMap};
 
-use bevy_ecs::entity::Entity;
+use bevy_ecs::{entity::Entity, prelude::Event};
 
 use naia_bevy_shared::{
     Channel, ChannelKind, ComponentKind, Message, MessageContainer, MessageKind, Replicate, Tick,
@@ -8,18 +8,23 @@ use naia_bevy_shared::{
 use naia_server::{Events, NaiaServerError, User, UserKey};
 
 // ConnectEvent
+#[derive(Event)]
 pub struct ConnectEvent(pub UserKey);
 
 // DisconnectEvent
+#[derive(Event)]
 pub struct DisconnectEvent(pub UserKey, pub User);
 
 // ErrorEvent
+#[derive(Event)]
 pub struct ErrorEvent(pub NaiaServerError);
 
 // TickEvent
+#[derive(Event)]
 pub struct TickEvent(pub Tick);
 
 // AuthEvents
+#[derive(Event)]
 pub struct AuthEvents {
     inner: HashMap<MessageKind, Vec<(UserKey, MessageContainer)>>,
 }
@@ -45,6 +50,7 @@ impl AuthEvents {
 }
 
 // MessageEvents
+#[derive(Event)]
 pub struct MessageEvents {
     inner: HashMap<ChannelKind, HashMap<MessageKind, Vec<(UserKey, MessageContainer)>>>,
 }
@@ -88,12 +94,15 @@ fn convert_messages<M: Message>(
 }
 
 // SpawnEntityEvent
+#[derive(Event)]
 pub struct SpawnEntityEvent(pub UserKey, pub Entity);
 
 // DespawnEntityEvent
+#[derive(Event)]
 pub struct DespawnEntityEvent(pub UserKey, pub Entity);
 
 // InsertComponentEvent
+#[derive(Event)]
 pub struct InsertComponentEvents {
     inner: HashMap<ComponentKind, Vec<(UserKey, Entity)>>,
 }
@@ -113,6 +122,7 @@ impl InsertComponentEvents {
 }
 
 // UpdateComponentEvents
+#[derive(Event)]
 pub struct UpdateComponentEvents {
     inner: HashMap<ComponentKind, Vec<(UserKey, Entity)>>,
 }
@@ -133,6 +143,7 @@ impl UpdateComponentEvents {
 }
 
 // RemoveComponentEvents
+#[derive(Event)]
 pub struct RemoveComponentEvents {
     inner: HashMap<ComponentKind, Vec<(UserKey, Entity, Box<dyn Replicate>)>>,
 }

--- a/adapters/bevy/server/src/plugin.rs
+++ b/adapters/bevy/server/src/plugin.rs
@@ -1,7 +1,7 @@
 use std::{ops::DerefMut, sync::Mutex};
 
-use bevy_app::{App, Plugin as PluginType};
-use bevy_ecs::{entity::Entity, schedule::IntoSystemConfig};
+use bevy_app::{App, Plugin as PluginType, Update};
+use bevy_ecs::{entity::Entity, schedule::IntoSystemConfigs};
 
 use naia_bevy_shared::{BeforeReceiveEvents, Protocol, SharedPlugin};
 use naia_server::{Server, ServerConfig};
@@ -54,7 +54,7 @@ impl PluginType for Plugin {
 
         app
             // SHARED PLUGIN //
-            .add_plugin(SharedPlugin)
+            .add_plugins(SharedPlugin)
             // RESOURCES //
             .insert_resource(server)
             // EVENTS //
@@ -70,6 +70,6 @@ impl PluginType for Plugin {
             .add_event::<UpdateComponentEvents>()
             .add_event::<RemoveComponentEvents>()
             // SYSTEMS //
-            .add_system(before_receive_events.in_set(BeforeReceiveEvents));
+            .add_systems(Update, before_receive_events.in_set(BeforeReceiveEvents));
     }
 }

--- a/adapters/bevy/shared/Cargo.toml
+++ b/adapters/bevy/shared/Cargo.toml
@@ -16,5 +16,5 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 naia-shared = { version = "0.21", path = "../../../shared", features = ["bevy_support", "wbindgen"] }
-bevy_app = { version = "0.10", default-features=false }
-bevy_ecs = { version = "0.10", default-features=false }
+bevy_app = { version = "0.11", default-features=false }
+bevy_ecs = { version = "0.11", default-features=false }

--- a/adapters/bevy/shared/src/change_detection.rs
+++ b/adapters/bevy/shared/src/change_detection.rs
@@ -1,6 +1,7 @@
 use bevy_ecs::{
     entity::Entity,
     event::EventWriter,
+    prelude::Event,
     query::{Added, With},
     removal_detection::RemovedComponents,
     system::Query,
@@ -10,6 +11,7 @@ use naia_shared::{ComponentKind, Replicate};
 
 use crate::HostOwned;
 
+#[derive(Event)]
 pub enum HostSyncEvent {
     Insert(Entity, ComponentKind),
     Remove(Entity, ComponentKind),

--- a/adapters/bevy/shared/src/component_access.rs
+++ b/adapters/bevy/shared/src/component_access.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, marker::PhantomData};
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::{entity::Entity, schedule::IntoSystemConfigs, world::World};
 
 use naia_shared::{ReplicaDynMutWrapper, ReplicaDynRefWrapper, Replicate};
@@ -51,6 +51,7 @@ impl<R: Replicate> ComponentAccessor<R> {
 impl<R: Replicate> ComponentAccess for ComponentAccessor<R> {
     fn add_systems(&self, app: &mut App) {
         app.add_systems(
+            Update,
             (on_component_added::<R>, on_component_removed::<R>)
                 .chain()
                 .in_set(HostSyncChangeTracking),
@@ -97,6 +98,7 @@ impl<R: Replicate> ComponentAccess for ComponentAccessor<R> {
     ) {
         let mut query = world.query::<&mut R>();
         unsafe {
+            let world = world.as_unsafe_world_cell();
             if let Ok(immutable_component) = query.get_unchecked(world, *immutable_entity) {
                 if let Ok(mut mutable_component) = query.get_unchecked(world, *mutable_entity) {
                     let some_r: &R = &immutable_component;

--- a/adapters/bevy/shared/src/plugin.rs
+++ b/adapters/bevy/shared/src/plugin.rs
@@ -1,5 +1,6 @@
-use bevy_app::{App, Plugin as PluginType};
-use bevy_ecs::schedule::{IntoSystemConfig, IntoSystemSetConfig};
+use bevy_app::{App, Plugin as PluginType, Update};
+use bevy_ecs::schedule::IntoSystemConfigs;
+use bevy_ecs::schedule::IntoSystemSetConfig;
 
 use crate::{
     change_detection::{on_despawn, HostSyncEvent},
@@ -15,9 +16,9 @@ impl PluginType for SharedPlugin {
             // EVENTS //
             .add_event::<HostSyncEvent>()
             // SYSTEM SETS //
-            .configure_set(HostSyncChangeTracking.before(BeforeReceiveEvents))
-            .configure_set(BeforeReceiveEvents.before(ReceiveEvents))
+            .configure_set(Update, HostSyncChangeTracking.before(BeforeReceiveEvents))
+            .configure_set(Update, BeforeReceiveEvents.before(ReceiveEvents))
             // SYSTEMS //
-            .add_system(on_despawn.in_set(HostSyncChangeTracking));
+            .add_systems(Update, on_despawn.in_set(HostSyncChangeTracking));
     }
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ transport_udp = [ "local_ipaddress" ]
 [dependencies]
 naia-shared = { version = "0.21", path = "../shared" }
 naia-client-socket = { version = "0.20", path = "../socket/client", optional = true }
-bevy_ecs = { version = "0.10", default_features = false, optional = true }
+bevy_ecs = { version = "0.11", default_features = false, optional = true }
 local_ipaddress = { version = "0.1", optional = true }
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }

--- a/demos/bevy/client/Cargo.toml
+++ b/demos/bevy/client/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 naia-bevy-client = { path = "../../../adapters/bevy/client", features = ["transport_webrtc"] }
 naia-bevy-demo-shared = { path = "../shared" }
 
-bevy = { version = "0.10.1", default_features = false, features = [ "bevy_asset", "bevy_winit", "bevy_core_pipeline", "bevy_render", "bevy_sprite", "x11"] }
+bevy = { version = "0.11.0", default_features = false, features = [ "bevy_asset", "bevy_winit", "bevy_core_pipeline", "bevy_render", "bevy_sprite", "x11"] }
 
 cfg-if = { version = "1.0" }
 

--- a/demos/bevy/client/src/app.rs
+++ b/demos/bevy/client/src/app.rs
@@ -1,6 +1,6 @@
 use bevy::{
     prelude::{
-        App, ClearColor, Color, IntoSystemConfig, IntoSystemConfigs, IntoSystemSetConfig, SystemSet,
+        App, ClearColor, Color, IntoSystemConfigs, IntoSystemSetConfig, SystemSet, Startup, Update,
     },
     DefaultPlugins,
 };
@@ -21,13 +21,14 @@ pub fn run() {
         // Bevy Plugins
         .add_plugins(DefaultPlugins)
         // Add Naia Client Plugin
-        .add_plugin(ClientPlugin::new(ClientConfig::default(), protocol()))
+        .add_plugins(ClientPlugin::new(ClientConfig::default(), protocol()))
         // Background Color
         .insert_resource(ClearColor(Color::BLACK))
         // Startup System
-        .add_startup_system(init)
+        .add_systems(Startup, init)
         // Receive Client Events
         .add_systems(
+            Update,
             (
                 events::connect_events,
                 events::disconnect_events,
@@ -43,11 +44,12 @@ pub fn run() {
                 .in_set(ReceiveEvents),
         )
         // Tick Event
-        .configure_set(Tick.after(ReceiveEvents))
-        .add_system(events::tick_events.in_set(Tick))
+        .configure_set(Update, Tick.after(ReceiveEvents))
+        .add_systems(Update, events::tick_events.in_set(Tick))
         // Realtime Gameplay Loop
-        .configure_set(MainLoop.after(Tick))
+        .configure_set(Update, MainLoop.after(Tick))
         .add_systems(
+            Update,
             (
                 input::key_input,
                 input::cursor_input,

--- a/demos/bevy/server/Cargo.toml
+++ b/demos/bevy/server/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 naia-bevy-demo-shared = { path = "../shared" }
 naia-bevy-server = { path = "../../../adapters/bevy/server", features = [ "transport_webrtc" ] }
-bevy_app = { version = "0.10", default-features=false }
-bevy_core = { version = "0.10", default-features=false }
-bevy_ecs = { version = "0.10", default-features=false }
-bevy_log = { version = "0.10", default-features=false }
+bevy_app = { version = "0.11", default-features=false }
+bevy_core = { version = "0.11", default-features=false }
+bevy_ecs = { version = "0.11", default-features=false }
+bevy_log = { version = "0.11", default-features=false }

--- a/demos/bevy/server/src/main.rs
+++ b/demos/bevy/server/src/main.rs
@@ -1,4 +1,4 @@
-use bevy_app::{App, ScheduleRunnerPlugin, ScheduleRunnerSettings};
+use bevy_app::{App, ScheduleRunnerPlugin, Startup, Update};
 use bevy_core::{FrameCountPlugin, TaskPoolPlugin, TypeRegistrationPlugin};
 use bevy_ecs::schedule::IntoSystemConfigs;
 use bevy_log::{info, LogPlugin};
@@ -18,20 +18,18 @@ fn main() {
     // Build App
     App::default()
         // Plugins
-        .add_plugin(TaskPoolPlugin::default())
-        .add_plugin(TypeRegistrationPlugin::default())
-        .add_plugin(FrameCountPlugin::default())
-        .insert_resource(
-            // this is needed to avoid running the server at uncapped FPS
-            ScheduleRunnerSettings::run_loop(Duration::from_millis(3)),
-        )
-        .add_plugin(ScheduleRunnerPlugin::default())
-        .add_plugin(LogPlugin::default())
-        .add_plugin(ServerPlugin::new(ServerConfig::default(), protocol()))
+        .add_plugins(TaskPoolPlugin::default())
+        .add_plugins(TypeRegistrationPlugin::default())
+        .add_plugins(FrameCountPlugin::default())
+        // this is needed to avoid running the server at uncapped FPS
+        .add_plugins(ScheduleRunnerPlugin::run_loop(Duration::from_millis(3)))
+        .add_plugins(LogPlugin::default())
+        .add_plugins(ServerPlugin::new(ServerConfig::default(), protocol()))
         // Startup System
-        .add_startup_system(init)
+        .add_systems(Startup, init)
         // Receive Server Events
         .add_systems(
+            Update,
             (
                 events::auth_events,
                 events::connect_events,

--- a/demos/bevy/shared/Cargo.toml
+++ b/demos/bevy/shared/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 
 [dependencies]
 naia-bevy-shared = { path = "../../../adapters/bevy/shared" }
-bevy_ecs = { version = "0.10", default-features=false}
+bevy_ecs = { version = "0.11", default-features=false}
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,7 +25,7 @@ transport_udp = []
 [dependencies]
 naia-shared = { version = "0.21", path = "../shared" }
 naia-server-socket = { version = "0.20", path = "../socket/server", optional = true }
-bevy_ecs = { version = "0.10", default_features = false, optional = true }
+bevy_ecs = { version = "0.11", default_features = false, optional = true }
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }
 ring = { version = "0.16.15" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -29,5 +29,5 @@ naia-serde = { version = "0.18", path = "serde" }
 log = { version = "0.4" }
 cfg-if = { version = "1.0" }
 js-sys = { version = "0.3", optional = true }
-bevy_ecs = { version = "0.10", default_features = false, optional = true }
+bevy_ecs = { version = "0.11", default_features = false, optional = true }
 zstd = { version = "0.12.2", optional = true }


### PR DESCRIPTION
This updates all bevy dependencies to 0.11 and fixes any compile errors that occurred in the adapter.
Most changes were very minor; the new schedule API and `Event` derives were probably the biggest change.
Thank you for naia! I'm looking forward to use it in an upcoming project. I hope this PR proves useful.