### PR TITLE
Update bevy to 0.12

### DIFF
--- a/adapters/bevy/client/Cargo.toml
+++ b/adapters/bevy/client/Cargo.toml
@@ -19,5 +19,5 @@ transport_udp = [ "naia-client/transport_udp" ]
 [dependencies]
 naia-client = { version = "0.21", path = "../../../client", features = ["bevy_support", "wbindgen"] }
 naia-bevy-shared = { version = "0.21", path = "../shared" }
-bevy_app = { version = "0.11", default-features=false }
-bevy_ecs = { version = "0.11", default-features=false }
+bevy_app = { version = "0.12", default-features=false }
+bevy_ecs = { version = "0.12", default-features=false }

--- a/adapters/bevy/server/Cargo.toml
+++ b/adapters/bevy/server/Cargo.toml
@@ -19,5 +19,5 @@ transport_udp = [ "naia-server/transport_udp" ]
 [dependencies]
 naia-server = { version = "0.21", path = "../../../server", features = ["bevy_support"] }
 naia-bevy-shared = { version = "0.21", path = "../shared" }
-bevy_app = { version = "0.11", default-features=false }
-bevy_ecs = { version = "0.11", default-features=false }
+bevy_app = { version = "0.12", default-features=false }
+bevy_ecs = { version = "0.12", default-features=false }

--- a/adapters/bevy/shared/Cargo.toml
+++ b/adapters/bevy/shared/Cargo.toml
@@ -16,5 +16,5 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 naia-shared = { version = "0.21", path = "../../../shared", features = ["bevy_support", "wbindgen"] }
-bevy_app = { version = "0.11", default-features=false }
-bevy_ecs = { version = "0.11", default-features=false }
+bevy_app = { version = "0.12", default-features=false }
+bevy_ecs = { version = "0.12", default-features=false }

--- a/adapters/bevy/shared/src/change_detection.rs
+++ b/adapters/bevy/shared/src/change_detection.rs
@@ -22,7 +22,7 @@ pub fn on_despawn(
     mut events: EventWriter<HostSyncEvent>,
     mut removals: RemovedComponents<HostOwned>,
 ) {
-    for entity in removals.iter() {
+    for entity in removals.read() {
         events.send(HostSyncEvent::Despawn(entity));
     }
 }
@@ -41,7 +41,7 @@ pub fn on_component_removed<R: Replicate>(
     query: Query<Entity, With<HostOwned>>,
     mut removals: RemovedComponents<R>,
 ) {
-    for removal_entity in removals.iter() {
+    for removal_entity in removals.read() {
         if let Ok(entity) = query.get(removal_entity) {
             events.send(HostSyncEvent::Remove(entity, ComponentKind::of::<R>()));
         }

--- a/adapters/bevy/shared/src/plugin.rs
+++ b/adapters/bevy/shared/src/plugin.rs
@@ -1,5 +1,5 @@
 use bevy_app::{App, Plugin as PluginType, Update};
-use bevy_ecs::schedule::{IntoSystemConfigs, IntoSystemSetConfig};
+use bevy_ecs::schedule::{IntoSystemConfigs, IntoSystemSetConfigs};
 
 use crate::{
     change_detection::{on_despawn, HostSyncEvent},
@@ -15,8 +15,8 @@ impl PluginType for SharedPlugin {
             // EVENTS //
             .add_event::<HostSyncEvent>()
             // SYSTEM SETS //
-            .configure_set(Update, HostSyncChangeTracking.before(BeforeReceiveEvents))
-            .configure_set(Update, BeforeReceiveEvents.before(ReceiveEvents))
+            .configure_sets(Update, HostSyncChangeTracking.before(BeforeReceiveEvents))
+            .configure_sets(Update, BeforeReceiveEvents.before(ReceiveEvents))
             // SYSTEMS //
             .add_systems(Update, on_despawn.in_set(HostSyncChangeTracking));
     }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ transport_udp = [ "local_ipaddress" ]
 [dependencies]
 naia-shared = { version = "0.21", path = "../shared" }
 naia-client-socket = { version = "0.20", path = "../socket/client", optional = true }
-bevy_ecs = { version = "0.11", default_features = false, optional = true }
+bevy_ecs = { version = "0.12", default_features = false, optional = true }
 local_ipaddress = { version = "0.1", optional = true }
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }

--- a/demos/bevy/client/Cargo.toml
+++ b/demos/bevy/client/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 naia-bevy-client = { path = "../../../adapters/bevy/client", features = ["transport_webrtc"] }
 naia-bevy-demo-shared = { path = "../shared" }
 
-bevy = { version = "0.11.2", default_features = false, features = [ "bevy_asset", "bevy_winit", "bevy_core_pipeline", "bevy_render", "bevy_sprite", "x11", "webgl2"] }
+bevy = { version = "0.12", default_features = false, features = [ "bevy_asset", "bevy_winit", "bevy_core_pipeline", "bevy_render", "bevy_sprite", "x11", "webgl2"] }
 
 cfg-if = { version = "1.0" }
 

--- a/demos/bevy/client/src/app.rs
+++ b/demos/bevy/client/src/app.rs
@@ -1,6 +1,6 @@
 use bevy::{
     prelude::{
-        App, ClearColor, Color, IntoSystemConfigs, IntoSystemSetConfig, SystemSet, Startup, Update,
+        App, ClearColor, Color, IntoSystemConfigs, IntoSystemSetConfigs, Startup, SystemSet, Update,
     },
     DefaultPlugins,
 };
@@ -44,10 +44,10 @@ pub fn run() {
                 .in_set(ReceiveEvents),
         )
         // Tick Event
-        .configure_set(Update, Tick.after(ReceiveEvents))
+        .configure_sets(Update, Tick.after(ReceiveEvents))
         .add_systems(Update, events::tick_events.in_set(Tick))
         // Realtime Gameplay Loop
-        .configure_set(Update, MainLoop.after(Tick))
+        .configure_sets(Update, MainLoop.after(Tick))
         .add_systems(
             Update,
             (

--- a/demos/bevy/server/Cargo.toml
+++ b/demos/bevy/server/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 naia-bevy-demo-shared = { path = "../shared" }
 naia-bevy-server = { path = "../../../adapters/bevy/server", features = [ "transport_webrtc" ] }
-bevy_app = { version = "0.11.2", default-features=false }
-bevy_core = { version = "0.11.2", default-features=false }
-bevy_ecs = { version = "0.11.2", default-features=false }
-bevy_log = { version = "0.11.2", default-features=false }
+bevy_app = { version = "0.12", default-features=false }
+bevy_core = { version = "0.12", default-features=false }
+bevy_ecs = { version = "0.12", default-features=false }
+bevy_log = { version = "0.12", default-features=false }

--- a/demos/bevy/server/src/systems/events.rs
+++ b/demos/bevy/server/src/systems/events.rs
@@ -23,7 +23,7 @@ use naia_bevy_demo_shared::{
 use crate::resources::Global;
 
 pub fn auth_events(mut server: Server, mut event_reader: EventReader<AuthEvents>) {
-    for events in event_reader.iter() {
+    for events in event_reader.read() {
         for (user_key, auth) in events.read::<Auth>() {
             if auth.username == "charlie" && auth.password == "12345" {
                 // Accept incoming connection
@@ -42,7 +42,7 @@ pub fn connect_events(
     mut global: ResMut<Global>,
     mut event_reader: EventReader<ConnectEvent>,
 ) {
-    for ConnectEvent(user_key) in event_reader.iter() {
+    for ConnectEvent(user_key) in event_reader.read() {
         let address = server
             .user_mut(user_key)
             // Add User to the main Room
@@ -112,7 +112,7 @@ pub fn disconnect_events(
     mut global: ResMut<Global>,
     mut event_reader: EventReader<DisconnectEvent>,
 ) {
-    for DisconnectEvent(user_key, user) in event_reader.iter() {
+    for DisconnectEvent(user_key, user) in event_reader.read() {
         info!("Naia Server disconnected from: {:?}", user.address);
 
         if let Some(entity) = global.user_to_square_map.remove(user_key) {
@@ -134,7 +134,7 @@ pub fn disconnect_events(
 }
 
 pub fn error_events(mut event_reader: EventReader<ErrorEvent>) {
-    for ErrorEvent(error) in event_reader.iter() {
+    for ErrorEvent(error) in event_reader.read() {
         info!("Naia Server Error: {:?}", error);
     }
 }
@@ -146,7 +146,7 @@ pub fn tick_events(
 ) {
     let mut has_ticked = false;
 
-    for TickEvent(server_tick) in tick_reader.iter() {
+    for TickEvent(server_tick) in tick_reader.read() {
         has_ticked = true;
 
         // All game logic should happen here, on a tick event
@@ -179,13 +179,13 @@ pub fn tick_events(
 }
 
 pub fn spawn_entity_events(mut event_reader: EventReader<SpawnEntityEvent>) {
-    for SpawnEntityEvent(_, _) in event_reader.iter() {
+    for SpawnEntityEvent(_, _) in event_reader.read() {
         info!("spawned client entity");
     }
 }
 
 pub fn despawn_entity_events(mut event_reader: EventReader<DespawnEntityEvent>) {
-    for DespawnEntityEvent(_, _) in event_reader.iter() {
+    for DespawnEntityEvent(_, _) in event_reader.read() {
         info!("despawned client entity");
     }
 }
@@ -197,7 +197,7 @@ pub fn insert_component_events(
     mut event_reader: EventReader<InsertComponentEvents>,
     position_query: Query<&Position>,
 ) {
-    for events in event_reader.iter() {
+    for events in event_reader.read() {
         for (user_key, client_entity) in events.read::<Position>() {
             info!("insert component into client entity");
 
@@ -252,7 +252,7 @@ pub fn update_component_events(
     mut event_reader: EventReader<UpdateComponentEvents>,
     mut position_query: Query<&mut Position>,
 ) {
-    for events in event_reader.iter() {
+    for events in event_reader.read() {
         for (_user_key, client_entity) in events.read::<Position>() {
             if let Some(server_entity) = global.client_to_server_cursor_map.get(&client_entity) {
                 if let Ok([client_position, mut server_position]) =
@@ -267,7 +267,7 @@ pub fn update_component_events(
 }
 
 pub fn remove_component_events(mut event_reader: EventReader<RemoveComponentEvents>) {
-    for events in event_reader.iter() {
+    for events in event_reader.read() {
         for (_user_key, _entity, _component) in events.read::<Position>() {
             info!("removed Position component from client entity");
         }

--- a/demos/bevy/shared/Cargo.toml
+++ b/demos/bevy/shared/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 
 [dependencies]
 naia-bevy-shared = { path = "../../../adapters/bevy/shared" }
-bevy_ecs = { version = "0.11.2", default-features=false}
+bevy_ecs = { version = "0.12", default-features=false}
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,7 +25,7 @@ transport_udp = []
 [dependencies]
 naia-shared = { version = "0.21", path = "../shared" }
 naia-server-socket = { version = "0.20", path = "../socket/server", optional = true }
-bevy_ecs = { version = "0.11", default_features = false, optional = true }
+bevy_ecs = { version = "0.12", default_features = false, optional = true }
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }
 ring = { version = "0.16.15" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -29,5 +29,5 @@ naia-serde = { version = "0.18", path = "serde" }
 log = { version = "0.4" }
 cfg-if = { version = "1.0" }
 js-sys = { version = "0.3", optional = true }
-bevy_ecs = { version = "0.11", default_features = false, optional = true }
+bevy_ecs = { version = "0.12", default_features = false, optional = true }
 zstd = { version = "0.12.2", optional = true }


### PR DESCRIPTION
Thank you to put your effort to make great crate! 

This updates all bevy dependencies to 0.12 and fixes any compile errors/warning that occurred in the adapter.

Tested with bevy demo and my personal card game.

![image](https://github.com/naia-lib/naia/assets/72777913/b025527e-3456-4776-b16a-4af1a684d095)
