### PR TITLE
update Bevy to 0.13.2

### DIFF
--- a/adapters/bevy/client/Cargo.toml
+++ b/adapters/bevy/client/Cargo.toml
@@ -19,6 +19,6 @@ transport_udp = [ "naia-client/transport_udp" ]
 [dependencies]
 naia-client = { version = "0.22", path = "../../../client", features = ["bevy_support", "wbindgen"] }
 naia-bevy-shared = { version = "0.22", path = "../shared" }
-bevy_app = { version = "0.12.1", default-features=false }
-bevy_ecs = { version = "0.12.1", default-features=false }
+bevy_app = { version = "0.13.2", default-features=false }
+bevy_ecs = { version = "0.13.2", default-features=false }
 log = { version = "0.4" }

--- a/adapters/bevy/client/src/lib.rs
+++ b/adapters/bevy/client/src/lib.rs
@@ -15,5 +15,6 @@ mod systems;
 
 pub use client::Client;
 pub use commands::CommandsExt;
+pub use commands::EntityCommandsExt;
 pub use components::{ClientOwned, ServerOwned};
 pub use plugin::Plugin;

--- a/adapters/bevy/server/Cargo.toml
+++ b/adapters/bevy/server/Cargo.toml
@@ -19,6 +19,6 @@ transport_udp = [ "naia-server/transport_udp" ]
 [dependencies]
 naia-server = { version = "0.22", path = "../../../server", features = ["bevy_support"] }
 naia-bevy-shared = { version = "0.22", path = "../shared" }
-bevy_app = { version = "0.12.1", default-features=false }
-bevy_ecs = { version = "0.12.1", default-features=false }
+bevy_app = { version = "0.13.2", default-features=false }
+bevy_ecs = { version = "0.13.2", default-features=false }
 log = { version = "0.4" }

--- a/adapters/bevy/server/src/commands.rs
+++ b/adapters/bevy/server/src/commands.rs
@@ -10,37 +10,31 @@ use naia_server::{ReplicationConfig, Server as NaiaServer, UserKey};
 use crate::Server;
 
 // Bevy Commands Extension
-pub trait CommandsExt<'w, 's, 'a> {
-    fn enable_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a>;
-    fn disable_replication(&'a mut self, server: &mut Server)
-        -> &'a mut EntityCommands<'w, 's, 'a>;
-    fn configure_replication(
-        &'a mut self,
-        config: ReplicationConfig,
-    ) -> &'a mut EntityCommands<'w, 's, 'a>;
+pub trait EntityCommandsExt<'a> {
+    fn enable_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a>;
+    fn disable_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a>;
+    fn configure_replication(&'a mut self, config: ReplicationConfig)
+        -> &'a mut EntityCommands<'a>;
     fn replication_config(&'a self, server: &Server) -> Option<ReplicationConfig>;
     fn give_authority(
         &'a mut self,
         server: &mut Server,
         user_key: &UserKey,
-    ) -> &'a mut EntityCommands<'w, 's, 'a>;
-    fn take_authority(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a>;
+    ) -> &'a mut EntityCommands<'a>;
+    fn take_authority(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a>;
     fn authority(&'a self, server: &Server) -> Option<EntityAuthStatus>;
-    fn pause_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a>;
-    fn resume_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a>;
+    fn pause_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a>;
+    fn resume_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a>;
 }
 
-impl<'w, 's, 'a> CommandsExt<'w, 's, 'a> for EntityCommands<'w, 's, 'a> {
-    fn enable_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a> {
+impl<'a> EntityCommandsExt<'a> for EntityCommands<'a> {
+    fn enable_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a> {
         server.enable_replication(&self.id());
         self.insert(HostOwned);
         return self;
     }
 
-    fn disable_replication(
-        &'a mut self,
-        server: &mut Server,
-    ) -> &'a mut EntityCommands<'w, 's, 'a> {
+    fn disable_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a> {
         server.disable_replication(&self.id());
         self.remove::<HostOwned>();
         return self;
@@ -49,9 +43,9 @@ impl<'w, 's, 'a> CommandsExt<'w, 's, 'a> for EntityCommands<'w, 's, 'a> {
     fn configure_replication(
         &'a mut self,
         config: ReplicationConfig,
-    ) -> &'a mut EntityCommands<'w, 's, 'a> {
+    ) -> &'a mut EntityCommands<'a> {
         let entity = self.id();
-        let commands = self.commands();
+        let mut commands = self.commands();
         let command = ConfigureReplicationCommand::new(entity, config);
         commands.add(command);
         return self;
@@ -65,11 +59,11 @@ impl<'w, 's, 'a> CommandsExt<'w, 's, 'a> for EntityCommands<'w, 's, 'a> {
         &'a mut self,
         _server: &mut Server,
         _user_key: &UserKey,
-    ) -> &'a mut EntityCommands<'w, 's, 'a> {
+    ) -> &'a mut EntityCommands<'a> {
         todo!()
     }
 
-    fn take_authority(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a> {
+    fn take_authority(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a> {
         server.entity_take_authority(&self.id());
         return self;
     }
@@ -78,12 +72,12 @@ impl<'w, 's, 'a> CommandsExt<'w, 's, 'a> for EntityCommands<'w, 's, 'a> {
         server.entity_authority_status(&self.id())
     }
 
-    fn pause_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a> {
+    fn pause_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a> {
         server.pause_replication(&self.id());
         return self;
     }
 
-    fn resume_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'w, 's, 'a> {
+    fn resume_replication(&'a mut self, server: &mut Server) -> &'a mut EntityCommands<'a> {
         server.resume_replication(&self.id());
         return self;
     }

--- a/adapters/bevy/server/src/lib.rs
+++ b/adapters/bevy/server/src/lib.rs
@@ -15,7 +15,7 @@ mod plugin;
 mod server;
 mod systems;
 
-pub use commands::CommandsExt;
+pub use commands::EntityCommandsExt;
 pub use components::{ClientOwned, ServerOwned};
 pub use plugin::Plugin;
 pub use server::Server;

--- a/adapters/bevy/server/src/systems.rs
+++ b/adapters/bevy/server/src/systems.rs
@@ -16,9 +16,8 @@ use crate::{ClientOwned, EntityAuthStatus};
 mod naia_events {
     pub use naia_server::{
         ConnectEvent, DelegateEntityEvent, DespawnEntityEvent, DisconnectEvent,
-        EntityAuthGrantEvent, EntityAuthResetEvent, ErrorEvent, InsertComponentEvent,
-        PublishEntityEvent, RemoveComponentEvent, SpawnEntityEvent, TickEvent,
-        UnpublishEntityEvent, UpdateComponentEvent,
+        EntityAuthGrantEvent, EntityAuthResetEvent, ErrorEvent, PublishEntityEvent,
+        SpawnEntityEvent, TickEvent, UnpublishEntityEvent,
     };
 }
 

--- a/adapters/bevy/shared/Cargo.toml
+++ b/adapters/bevy/shared/Cargo.toml
@@ -16,6 +16,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 naia-shared = { version = "0.22", path = "../../../shared", features = ["bevy_support", "wbindgen"] }
-bevy_app = { version = "0.12.1", default-features=false }
-bevy_ecs = { version = "0.12.1", default-features=false }
+bevy_app = { version = "0.13.2", default-features=false }
+bevy_ecs = { version = "0.13.2", default-features=false }
 log = { version = "0.4" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ transport_udp = [ "local_ipaddress" ]
 [dependencies]
 naia-shared = { version = "0.22", path = "../shared" }
 naia-client-socket = { version = "0.22", path = "../socket/client", optional = true }
-bevy_ecs = { version = "0.12.1", default_features = false, optional = true }
+bevy_ecs = { version = "0.13.2", default_features = false, optional = true }
 local_ipaddress = { version = "0.1", optional = true }
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }

--- a/demos/bevy/client/Cargo.toml
+++ b/demos/bevy/client/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 naia-bevy-client = { path = "../../../adapters/bevy/client", features = ["transport_webrtc"] }
 naia-bevy-demo-shared = { path = "../shared" }
 
-bevy = { version = "0.12.1", default_features = false, features = [ "bevy_asset", "bevy_winit", "bevy_core_pipeline", "bevy_render", "bevy_sprite", "x11", "webgl2"] }
+bevy = { version = "0.13.2", default_features = false, features = [ "bevy_asset", "bevy_winit", "bevy_core_pipeline", "bevy_render", "bevy_sprite", "x11", "webgl2"] }
 
 cfg-if = { version = "1.0" }
 

--- a/demos/bevy/client/src/systems/events.rs
+++ b/demos/bevy/client/src/systems/events.rs
@@ -14,7 +14,7 @@ use naia_bevy_client::{
         MessageEvents, PublishEntityEvent, RejectEvent, RemoveComponentEvents, SpawnEntityEvent,
         UnpublishEntityEvent, UpdateComponentEvents,
     },
-    sequence_greater_than, Client, CommandsExt, Random, Replicate, Tick,
+    sequence_greater_than, Client, CommandsExt, EntityCommandsExt, Random, Replicate, Tick,
 };
 use naia_bevy_demo_shared::{
     behavior as shared_behavior,
@@ -99,8 +99,8 @@ pub fn message_events(
                 // Here we create a local copy of the Player entity, to use for client-side prediction
                 if let Ok(position) = position_query.get(entity) {
                     let prediction_entity = commands
-                        .entity(entity)
-                        .local_duplicate() // copies all Replicate components as well
+                        .local_duplicate(entity)
+                        // copies all Replicate components as well
                         .insert(SpriteBundle {
                             sprite: Sprite {
                                 custom_size: Some(Vec2::new(SQUARE_SIZE, SQUARE_SIZE)),
@@ -348,7 +348,8 @@ pub fn tick_events(
     let Some(predicted_entity) = global
         .owned_entity
         .as_ref()
-        .map(|owned_entity| owned_entity.predicted) else {
+        .map(|owned_entity| owned_entity.predicted)
+    else {
         // No owned Entity
         return;
     };

--- a/demos/bevy/client/src/systems/init.rs
+++ b/demos/bevy/client/src/systems/init.rs
@@ -1,5 +1,6 @@
-use bevy::prelude::{
-    info, shape, Assets, Camera2dBundle, Color, ColorMaterial, Commands, Mesh, ResMut,
+use bevy::{
+    math::primitives,
+    prelude::{info, Assets, Camera2dBundle, Color, ColorMaterial, Commands, Mesh, ResMut},
 };
 
 use naia_bevy_client::{transport::webrtc, Client};
@@ -36,7 +37,7 @@ pub fn init(
     global.aqua = materials.add(ColorMaterial::from(Color::AQUAMARINE));
 
     // Load shapes
-    global.circle = meshes.add(shape::Circle::new(6.).into());
+    global.circle = meshes.add(primitives::Circle::new(6.));
 
     // Insert Global Resource
     commands.insert_resource(global);

--- a/demos/bevy/client/src/systems/input.rs
+++ b/demos/bevy/client/src/systems/input.rs
@@ -1,6 +1,8 @@
-use bevy::prelude::{Commands, Input, KeyCode, Query, Res, ResMut, Vec2, Window};
-
-use naia_bevy_client::{Client, CommandsExt, ReplicationConfig};
+use bevy::{
+    input::ButtonInput,
+    prelude::{Commands, KeyCode, Query, Res, ResMut, Vec2, Window},
+};
+use naia_bevy_client::{Client, EntityCommandsExt, ReplicationConfig};
 use naia_bevy_demo_shared::{components::Position, messages::KeyCommand};
 
 use crate::resources::Global;
@@ -9,13 +11,13 @@ pub fn key_input(
     client: Client,
     mut commands: Commands,
     mut global: ResMut<Global>,
-    keyboard_input: Res<Input<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
-    let w = keyboard_input.pressed(KeyCode::W);
-    let s = keyboard_input.pressed(KeyCode::S);
-    let a = keyboard_input.pressed(KeyCode::A);
-    let d = keyboard_input.pressed(KeyCode::D);
-    let x = keyboard_input.pressed(KeyCode::X);
+    let w = keyboard_input.pressed(KeyCode::KeyW);
+    let s = keyboard_input.pressed(KeyCode::KeyS);
+    let a = keyboard_input.pressed(KeyCode::KeyA);
+    let d = keyboard_input.pressed(KeyCode::KeyD);
+    let x = keyboard_input.pressed(KeyCode::KeyX);
 
     if let Some(command) = &mut global.queued_command {
         if w {
@@ -68,7 +70,7 @@ pub fn cursor_input(
 
 fn window_relative_mouse_position(window: &Window) -> Option<Vec2> {
     let Some(cursor_pos) = window.cursor_position() else {
-        return None
+        return None;
     };
 
     Some(Vec2::new(

--- a/demos/bevy/server/Cargo.toml
+++ b/demos/bevy/server/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 naia-bevy-demo-shared = { path = "../shared" }
 naia-bevy-server = { path = "../../../adapters/bevy/server", features = [ "transport_webrtc" ] }
-bevy_app = { version = "0.12.1", default-features=false }
-bevy_core = { version = "0.12.1", default-features=false }
-bevy_ecs = { version = "0.12.1", default-features=false }
-bevy_log = { version = "0.12.1", default-features=false }
+bevy_app = { version = "0.13.2", default-features=false }
+bevy_core = { version = "0.13.2", default-features=false }
+bevy_ecs = { version = "0.13.2", default-features=false }
+bevy_log = { version = "0.13.2", default-features=false }

--- a/demos/bevy/server/src/systems/events.rs
+++ b/demos/bevy/server/src/systems/events.rs
@@ -10,7 +10,7 @@ use naia_bevy_server::{
         InsertComponentEvents, PublishEntityEvent, RemoveComponentEvents, SpawnEntityEvent,
         TickEvent, UnpublishEntityEvent, UpdateComponentEvents,
     },
-    CommandsExt, Random, ReplicationConfig, Server,
+    EntityCommandsExt, Random, ReplicationConfig, Server,
 };
 
 use naia_bevy_demo_shared::{

--- a/demos/bevy/shared/Cargo.toml
+++ b/demos/bevy/shared/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 
 [dependencies]
 naia-bevy-shared = { path = "../../../adapters/bevy/shared" }
-bevy_ecs = { version = "0.12.1", default-features=false}
+bevy_ecs = { version = "0.13.2", default-features=false}
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,7 +25,7 @@ transport_udp = []
 [dependencies]
 naia-shared = { version = "0.22", path = "../shared" }
 naia-server-socket = { version = "0.22", path = "../socket/server", optional = true }
-bevy_ecs = { version = "0.12.1", default_features = false, optional = true }
+bevy_ecs = { version = "0.13.2", default_features = false, optional = true }
 cfg-if = { version = "1.0" }
 log = { version = "0.4" }
 ring = { version = "0.16.15" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -29,5 +29,5 @@ naia-serde = { version = "0.22", path = "serde" }
 log = { version = "0.4" }
 cfg-if = { version = "1.0" }
 js-sys = { version = "0.3", optional = true }
-bevy_ecs = { version = "0.12.1", default_features = false, optional = true }
+bevy_ecs = { version = "0.13.2", default_features = false, optional = true }
 zstd = { version = "0.12.2", optional = true }


### PR DESCRIPTION
Major changes to [client commands.rs](https://github.com/Robsutar/naia/blob/bevy-0.13.2/adapters/bevy/client/src/commands.rs) and [server commands.rs](https://github.com/Robsutar/naia/blob/bevy-0.13.2/adapters/bevy/server/src/commands.rs) due to https://github.com/bevyengine/bevy/pull/11316.

with additional consideration at [client commands.rs](https://github.com/Robsutar/naia/blob/bevy-0.13.2/adapters/bevy/client/src/commands.rs); now it has two extensions ([CommandtExt](https://github.com/Robsutar/naia/blob/32c443d22ab1f868be20109c38babe7773ae05af/adapters/bevy/client/src/commands.rs#L12) and [EntityCommandsExt](https://github.com/Robsutar/naia/blob/32c443d22ab1f868be20109c38babe7773ae05af/adapters/bevy/client/src/commands.rs#L27)) due to https://github.com/bevyengine/bevy/pull/11445.

Tested with [demos/bevy](https://github.com/Robsutar/naia/tree/bevy-0.13.2/demos/bevy), two clients and one server.