### PR TITLE
fix: stop panic on net_id_to_kind, pass a SerdeErr instead for now.

### DIFF
--- a/demos/hecs/server/src/systems/events.rs
+++ b/demos/hecs/server/src/systems/events.rs
@@ -31,7 +31,7 @@ pub fn process_events(app: &mut App) {
             app.has_user = true;
         }
         for (_user_key, user) in events.read::<DisconnectEvent>() {
-            info!("Naia Server disconnected from: {:?}", user.address);
+            info!("Naia Server disconnected from: {:?}", user.address());
         }
         for _ in events.read::<TickEvent>() {
             app.tick();

--- a/demos/hecs/server/src/systems/tick.rs
+++ b/demos/hecs/server/src/systems/tick.rs
@@ -107,9 +107,9 @@ pub fn check_scopes(app: &mut App) {
                 let x = *position.x;
 
                 if (50..=200).contains(&x) {
-                    server.user_scope(&user_key).include(&entity);
+                    server.user_scope_mut(&user_key).include(&entity);
                 } else {
-                    server.user_scope(&user_key).exclude(&entity);
+                    server.user_scope_mut(&user_key).exclude(&entity);
                 }
             }
         }

--- a/shared/src/messages/message_kinds.rs
+++ b/shared/src/messages/message_kinds.rs
@@ -33,7 +33,7 @@ impl MessageKind {
 
     pub fn de(message_kinds: &MessageKinds, reader: &mut BitReader) -> Result<Self, SerdeErr> {
         let net_id: NetId = NetId::de(reader)?;
-        Ok(message_kinds.net_id_to_kind(&net_id))
+        Ok(message_kinds.net_id_to_kind(&net_id)?)
     }
 }
 
@@ -79,10 +79,11 @@ impl MessageKinds {
         return self.kind_to_builder(&message_kind).read(reader, converter);
     }
 
-    fn net_id_to_kind(&self, net_id: &NetId) -> MessageKind {
-        return *self.net_id_map.get(net_id).expect(
-            "Must properly initialize Message with Protocol via `add_message()` function!",
-        );
+    fn net_id_to_kind(&self, net_id: &NetId) -> Result<MessageKind, SerdeErr> {
+        match self.net_id_map.get(net_id) {
+            Some(kind) => Ok(*kind),
+            None => Err(SerdeErr),
+        }
     }
 
     fn kind_to_net_id(&self, message_kind: &MessageKind) -> NetId {


### PR DESCRIPTION


```
C:\w\demos\naia [main ≡ +7 ~2 -0 !]> cargo e
There's no place like 127.0.0.1.
'cargo-e' 0.3.2 is latest.
workspace: naia/naia/Cargo.toml [1. client, 2. client, 3. shared, 4. shared, 5. derive, 6. derive, 7. serde, 8. server, 9. server, 10. test, 11. client, 12. shared, 13. server, 14. client, 15. shared, 16. server, 17. demo_world, 18. empty_world, 19. server, 20. shared, 21. app, 22. wasm_bindgen, 23. miniquad, 24. server, 25. shared, 26. client, 27. server, 28. shared, 29. client, 30. server, 31. shared, 32. client, 33. server, 34. shared, 35. app, 36. wasm_bindgen, 37. miniquad]
package: naia/Cargo.toml
(6 targets: 0 examples, 6 binaries)
== press q, t, wait for 15 seconds, or other key to continue.
  1: [demos\basic\server bin*] $server > binary > naia-basic-server-demo  (1 run)
  2: [demos\bevy\server bin*] $server > binary > naia-bevy-server-demo  (13 runs)
  3: [demos\hecs\server bin*] $server > binary > naia-hecs-server-demo  (1 run)
  4: [demos\macroquad\server bin*] $server > binary > naia-macroquad-server-demo
  5: [demos\socket\client\wasm_bindgen bin*] $wasm_bindgen > binary > app  (2 runs)
  6: [demos\socket\server bin*] $server > binary > naia-server-socket-demo  (4 runs)
* == # to run, tui, e<#> edit, i<#> info, 'q' to quit (waiting 15 seconds)
3

Target origin: TomlSpecified("C:\\w\\demos\\naia\\demos\\hecs\\server\\Cargo.toml")
[cargo-e debug] selecting --package 'naia-hecs-server-demo' for manifest C:\w\demos\naia\demos\hecs\server\Cargo.toml
[cargo-e debug] setting execution_dir to C:\w\demos\naia\demos\hecs\server
Running: cargo run --bin naia-hecs-server-demo --package naia-hecs-server-demo  [from Some("C:\\w\\demos\\naia\\demos\\hecs\\server")]
warning: hiding a lifetime that's elided elsewhere is confusing
  --> shared\serde\src\bit_reader.rs:88:19
   |
88 |     pub fn borrow(&self) -> BitReader {
   |                   ^^^^^     ^^^^^^^^^ the same lifetime is hidden here
   |                   |
   |                   the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
88 |     pub fn borrow(&self) -> BitReader<'_> {
   |                                      ++++

warning: `naia-serde` (lib) generated 1 warning (run `cargo fix --lib -p naia-serde` to apply 1 suggestion)
warning: hiding a lifetime that's elided elsewhere is confusing
  --> shared\src\world\component\component_update.rs:18:19
   |
18 |     pub fn reader(&self) -> BitReader {
   |                   ^^^^^     ^^^^^^^^^ the same lifetime is hidden here
   |                   |
   |                   the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
18 |     pub fn reader(&self) -> BitReader<'_> {
   |                                      ++++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> shared\src\world\component\component_update.rs:52:19
   |
52 |     pub fn reader(&self) -> BitReader {
   |                   ^^^^^     ^^^^^^^^^ the same lifetime is hidden here
   |                   |
   |                   the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
52 |     pub fn reader(&self) -> BitReader<'_> {
   |                                      ++++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> shared\src\world\host\mut_channel.rs:69:17
   |
69 |     pub fn mask(&self) -> RwLockReadGuard<DiffMask> {
   |                 ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
69 |     pub fn mask(&self) -> RwLockReadGuard<'_, DiffMask> {
   |                                           +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> shared\src\world\host\user_diff_handler.rs:52:9
   |
52 |         &self,
   |         ^^^^^ the lifetime is elided here
...
55 |     ) -> RwLockReadGuard<DiffMask> {
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
55 |     ) -> RwLockReadGuard<'_, DiffMask> {
   |                          +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> shared\src\world\host\world_channel.rs:684:17
    |
684 |     pub fn iter(&self) -> std::collections::hash_map::Iter<K, V> {
    |                 ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
684 |     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, K, V> {
    |                                                            +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> shared\src\world\host\world_channel.rs:729:17
    |
729 |     pub fn iter(&self) -> std::collections::hash_set::Iter<K> {
    |                 ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
729 |     pub fn iter(&self) -> std::collections::hash_set::Iter<'_, K> {
    |                                                            +++

warning: `naia-shared` (lib) generated 6 warnings (run `cargo fix --lib -p naia-shared` to apply 6 suggestions)
warning: hiding a lifetime that's elided elsewhere is confusing
  --> adapters\hecs\shared\src\world_proxy.rs:71:32
   |
71 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<R>> {
   |                                ^^^^^ the lifetime is elided here ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
71 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<'_, R>> {
   |                                                                                    +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> adapters\hecs\shared\src\world_proxy.rs:117:32
    |
117 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<R>> {
    |                                ^^^^^ the lifetime is elided here ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
117 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<'_, R>> {
    |                                                                                    +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> adapters\hecs\shared\src\world_proxy.rs:173:36
    |
173 |     fn component_mut<R: Replicate>(&mut self, entity: &Entity) -> Option<ReplicaMutWrapper<R>> {
    |                                    ^^^^^^^^^ the lifetime is elided here ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
173 |     fn component_mut<R: Replicate>(&mut self, entity: &Entity) -> Option<ReplicaMutWrapper<'_, R>> {
    |                                                                                            +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> adapters\hecs\shared\src\world_wrapper.rs:72:32
   |
72 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<R>> {
   |                                ^^^^^ the lifetime is elided here ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
72 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<'_, R>> {
   |                                                                                    +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> adapters\hecs\shared\src\world_wrapper.rs:102:32
    |
102 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<R>> {
    |                                ^^^^^ the lifetime is elided here ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
102 |     fn component<R: Replicate>(&self, entity: &Entity) -> Option<ReplicaRefWrapper<'_, R>> {
    |                                                                                    +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> adapters\hecs\shared\src\world_wrapper.rs:158:36
    |
158 |     fn component_mut<R: Replicate>(&mut self, entity: &Entity) -> Option<ReplicaMutWrapper<R>> {
    |                                    ^^^^^^^^^ the lifetime is elided here ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
158 |     fn component_mut<R: Replicate>(&mut self, entity: &Entity) -> Option<ReplicaMutWrapper<'_, R>> {
    |                                                                                            +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> server\src\room.rs:57:29
   |
57 |     pub(crate) fn user_keys(&self) -> Iter<UserKey> {
   |                             ^^^^^     ^^^^^^^^^^^^^ the same lifetime is hidden here
   |                             |
   |                             the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
57 |     pub(crate) fn user_keys(&self) -> Iter<'_, UserKey> {
   |                                            +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> server\src\room.rs:88:28
   |
88 |     pub(crate) fn entities(&self) -> Iter<E> {
   |                            ^^^^^     ^^^^^^^ the same lifetime is hidden here
   |                            |
   |                            the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
88 |     pub(crate) fn entities(&self) -> Iter<'_, E> {
   |                                           +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:488:45
    |
488 |     pub fn spawn_entity<W: WorldMutType<E>>(&mut self, mut world: W) -> EntityMut<E, W> {
    |                                             ^^^^^^^^^                   ^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                                             |
    |                                             the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
488 |     pub fn spawn_entity<W: WorldMutType<E>>(&mut self, mut world: W) -> EntityMut<'_, E, W> {
    |                                                                                   +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:812:39
    |
812 |     pub fn entity<W: WorldRefType<E>>(&self, world: W, entity: &E) -> EntityRef<E, W> {
    |                                       ^^^^^                           ^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                                       |
    |                                       the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
812 |     pub fn entity<W: WorldRefType<E>>(&self, world: W, entity: &E) -> EntityRef<'_, E, W> {
    |                                                                                 +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:822:43
    |
822 |     pub fn entity_mut<W: WorldMutType<E>>(&mut self, world: W, entity: &E) -> EntityMut<E, W> {
    |                                           ^^^^^^^^^                           ^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                                           |
    |                                           the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
822 |     pub fn entity_mut<W: WorldMutType<E>>(&mut self, world: W, entity: &E) -> EntityMut<'_, E, W> {
    |                                                                                         +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:851:17
    |
851 |     pub fn user(&self, user_key: &UserKey) -> UserRef<E> {
    |                 ^^^^^                         ^^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
851 |     pub fn user(&self, user_key: &UserKey) -> UserRef<'_, E> {
    |                                                       +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:861:21
    |
861 |     pub fn user_mut(&mut self, user_key: &UserKey) -> UserMut<E> {
    |                     ^^^^^^^^^                         ^^^^^^^^^^ the same lifetime is hidden here
    |                     |
    |                     the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
861 |     pub fn user_mut(&mut self, user_key: &UserKey) -> UserMut<'_, E> {
    |                                                               +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:890:23
    |
890 |     pub fn user_scope(&self, user_key: &UserKey) -> UserScopeRef<E> {
    |                       ^^^^^                         ^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                       |
    |                       the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
890 |     pub fn user_scope(&self, user_key: &UserKey) -> UserScopeRef<'_, E> {
    |                                                                  +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:899:27
    |
899 |     pub fn user_scope_mut(&mut self, user_key: &UserKey) -> UserScopeMut<E> {
    |                           ^^^^^^^^^                         ^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                           |
    |                           the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
899 |     pub fn user_scope_mut(&mut self, user_key: &UserKey) -> UserScopeMut<'_, E> {
    |                                                                          +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:911:22
    |
911 |     pub fn make_room(&mut self) -> RoomMut<E> {
    |                      ^^^^^^^^^     ^^^^^^^^^^ the same lifetime is hidden here
    |                      |
    |                      the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
911 |     pub fn make_room(&mut self) -> RoomMut<'_, E> {
    |                                            +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:925:17
    |
925 |     pub fn room(&self, room_key: &RoomKey) -> RoomRef<E> {
    |                 ^^^^^                         ^^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
925 |     pub fn room(&self, room_key: &RoomKey) -> RoomRef<'_, E> {
    |                                                       +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\server.rs:935:21
    |
935 |     pub fn room_mut(&mut self, room_key: &RoomKey) -> RoomMut<E> {
    |                     ^^^^^^^^^                         ^^^^^^^^^^ the same lifetime is hidden here
    |                     |
    |                     the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
935 |     pub fn room_mut(&mut self, room_key: &RoomKey) -> RoomMut<'_, E> {
    |                                                               +++

warning: hiding a lifetime that's elided elsewhere is confusing
    --> server\src\server.rs:1461:34
     |
1461 |     pub(crate) fn user_room_keys(&self, user_key: &UserKey) -> Option<Iter<RoomKey>> {
     |                                  ^^^^^ the lifetime is elided here    ^^^^^^^^^^^^^ the same lifetime is hidden here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
     |
1461 |     pub(crate) fn user_room_keys(&self, user_key: &UserKey) -> Option<Iter<'_, RoomKey>> {
     |                                                                            +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> server\src\user.rs:168:22
    |
168 |     pub fn room_keys(&self) -> Iter<RoomKey> {
    |                      ^^^^^     ^^^^^^^^^^^^^ the same lifetime is hidden here
    |                      |
    |                      the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
168 |     pub fn room_keys(&self) -> Iter<'_, RoomKey> {
    |                                     +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> server\src\world\entity_mut.rs:37:46
   |
37 |     pub fn component<R: ReplicatedComponent>(&mut self) -> Option<ReplicaMutWrapper<R>> {
   |                                              ^^^^^^^^^            ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                                              |
   |                                              the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
37 |     pub fn component<R: ReplicatedComponent>(&mut self) -> Option<ReplicaMutWrapper<'_, R>> {
   |                                                                                     +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> server\src\world\entity_ref.rs:31:46
   |
31 |     pub fn component<R: ReplicatedComponent>(&self) -> Option<ReplicaRefWrapper<R>> {
   |                                              ^^^^^            ^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                                              |
   |                                              the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
31 |     pub fn component<R: ReplicatedComponent>(&self) -> Option<ReplicaRefWrapper<'_, R>> {
   |                                                                                 +++

warning: `naia-hecs-shared` (lib) generated 6 warnings (run `cargo fix --lib -p naia-hecs-shared` to apply 6 suggestions)
warning: `naia-server` (lib) generated 16 warnings (run `cargo fix --lib -p naia-server` to apply 16 suggestions)
   Compiling naia-hecs-server-demo v0.1.0 (C:\w\demos\naia\demos\hecs\server)
warning: field `tick_count` is never read
  --> demos\hecs\server\src\app.rs:24:9
   |
19 | pub struct App {
   |            --- field in this struct
...
24 |     pub tick_count: u32,
   |         ^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `naia-hecs-server-demo` (bin "naia-hecs-server-demo") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.94s
     Running `C:\w\demos\naia\target\debug\naia-hecs-server-demo.exe`
2026-01-06T23:52:40.214Z INFO  [naia_hecs_server_demo::app] Naia Hecs Server Demo started
2026-01-06T23:52:40.233Z INFO  [webrtc_unreliable::server] new WebRTC data channel server listening on 127.0.0.1:14192, public addr 127.0.0.1:14192
2026-01-06T23:52:40.234Z INFO  [naia_server_socket::session] Session initiator available at POST http://127.0.0.1:14191/rtc_session
2026-01-06T23:55:14.945Z INFO  [naia_server_socket::session] Incoming WebRTC session request from 127.0.0.1:56191

thread 'main' (47708) panicked at shared\src\messages\message_kinds.rs:83:45:
Must properly initialize Message with Protocol via `add_message()` function!
stack backtrace:
   0: std::panicking::panic_handler
             at /rustc/3d8c1c1fc077d04658de63261d8ce2903546db13/library\std\src\panicking.rs:698
   1: core::panicking::panic_fmt
             at /rustc/3d8c1c1fc077d04658de63261d8ce2903546db13/library\core\src\panicking.rs:79
   2: core::panicking::panic_display
             at /rustc/3d8c1c1fc077d04658de63261d8ce2903546db13/library\core\src\panicking.rs:263
   3: core::option::expect_failed
             at /rustc/3d8c1c1fc077d04658de63261d8ce2903546db13/library\core\src\option.rs:2178
   4: enum2$<core::option::Option<ref$<naia_shared::messages::message_kinds::MessageKind> > >::expect<ref$<naia_shared::messages::message_kinds::MessageKind> >
             at C:\Users\dhorner\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\option.rs:965
   5: naia_shared::messages::message_kinds::MessageKinds::net_id_to_kind
             at C:\w\demos\naia\shared\src\messages\message_kinds.rs:83
   6: naia_shared::messages::message_kinds::MessageKind::de
             at C:\w\demos\naia\shared\src\messages\message_kinds.rs:36
   7: naia_shared::messages::message_kinds::MessageKinds::read
             at C:\w\demos\naia\shared\src\messages\message_kinds.rs:78
   8: naia_server::server::Server<hecs::entities::Entity>::maintain_socket<hecs::entities::Entity,ref_mut$<naia_hecs_shared::world_wrapper::WorldWrapper> >
             at C:\w\demos\naia\server\src\server.rs:1742
   9: naia_server::server::Server<hecs::entities::Entity>::receive<hecs::entities::Entity,ref_mut$<naia_hecs_shared::world_wrapper::WorldWrapper> >
             at C:\w\demos\naia\server\src\server.rs:147
  10: naia_hecs_server_demo::systems::events::process_events
             at .\src\systems\events.rs:9
  11: naia_hecs_server_demo::app::App::update
             at .\src\app.rs:48
  12: naia_hecs_server_demo::main
             at .\src\main.rs:21
  13: core::ops::function::FnOnce::call_once<enum2$<core::result::Result<tuple$<>,std::io::error::Error> > (*)(),tuple$<> >
             at C:\Users\dhorner\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2026-01-06T23:55:15.027Z WARN  [naia_server_socket::session] Unable to receive auth from session
2026-01-06T23:55:15.027Z WARN  [naia_server_socket::session] Unable to receive auth from sessionerror: process didn't exit successfully: `C:\w\demos\naia\target\debug\naia-hecs-server-demo.exe` (exit code: 101)

Process with PID 141216 finished ExitStatus(ExitStatus(101)) 0
ProcessManager senses pid 141216 cargo error, running again to capture and analyze
Process finished successfully.
```